### PR TITLE
feat(typescript): specify default success response type for angular s…

### DIFF
--- a/packages/typescript/src/lib/generators/services/angular-services/angular-service-generator.ts
+++ b/packages/typescript/src/lib/generators/services/angular-services/angular-service-generator.ts
@@ -243,7 +243,7 @@ export class DefaultTypeScriptAngularServiceGenerator
       { importType: 'type-import' },
     );
     const returnType = ctx.refs.abortablePromise([responseModelType]);
-    const accept = this.getEndpointSuccessResponse(ctx, endpoint)?.contentOptions[0]?.type ?? '*/*';
+    const accept = this.getEndpointSuccessResponseType(ctx, endpoint);
     const responseType = this.contentTypeToResponseType(accept);
     return ts.method<Builder>(this.getEndpointMethodName(ctx, endpoint), {
       accessModifier: 'public',
@@ -314,6 +314,19 @@ export class DefaultTypeScriptAngularServiceGenerator
         '\n',
       ),
     });
+  }
+
+  protected getEndpointSuccessResponseType(ctx: Context, endpoint: ApiEndpoint): string {
+    const response = this.getEndpointSuccessResponse(ctx, endpoint);
+    if (!response) return '*/*';
+
+    if (!ctx.config.defaultSuccessResponseType) return response.contentOptions[0]?.type ?? '*/*';
+
+    return (
+      response.contentOptions.find((x) => x.type === ctx.config.defaultSuccessResponseType)?.type ??
+      response.contentOptions[0]?.type ??
+      '*/*'
+    );
   }
 
   protected getEndpointSuccessResponse(ctx: Context, endpoint: ApiEndpoint) {

--- a/packages/typescript/src/lib/generators/services/angular-services/models.ts
+++ b/packages/typescript/src/lib/generators/services/angular-services/models.ts
@@ -70,6 +70,12 @@ export type TypeScriptAngularServicesGeneratorConfig = TypeScriptGeneratorConfig
   >;
 
   /**
+   * The default content type which is used for the success response. If not defined the first one defined in the OpenApi specification is used.
+   * @default undefined
+   */
+  defaultSuccessResponseType: Nullable<string>;
+
+  /**
    * The possible status codes that any API endpoint can return.
    * This is only used when `strictResponseTypes` is set to `false`.
    * @default
@@ -144,6 +150,7 @@ export const defaultTypeScriptAngularServicesGeneratorConfig: DefaultGenerationP
       403: null,
       500: null,
     },
+    defaultSuccessResponseType: undefined,
     possibleStatusCodes: [
       100, 101, 102, 103, 200, 201, 202, 203, 204, 205, 206, 207, 208, 226, 300, 301, 302, 303, 304, 305, 306, 307, 308,
       400, 401, 402, 403, 404, 405, 406, 407, 408, 409, 410, 411, 412, 413, 414, 415, 416, 417, 421, 422, 423, 424, 425,


### PR DESCRIPTION
…ervices (#18)

Fix for issue #18. You can now specify a default success response type via `defaultSuccessResponseType: 'application/json'`. If this type is not found the first one specified in the OpenApi specification is used, otherwise `'*/*'` is used, like before.