### PR TITLE
feat(typescript): add ability to specify default request content type

### DIFF
--- a/packages/typescript/deno.json
+++ b/packages/typescript/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@goast/typescript",
-  "version": "0.4.4",
+  "version": "0.5.0",
   "description": "Provides gOAst generators for generating TypeScript code from OpenAPI specifications.",
   "exports": "./mod.ts",
   "publish": {

--- a/packages/typescript/src/generators/services/angular-services/angular-service-generator.ts
+++ b/packages/typescript/src/generators/services/angular-services/angular-service-generator.ts
@@ -331,7 +331,7 @@ export class DefaultTypeScriptAngularServiceGenerator extends TypeScriptFileGene
   }
 
   protected getEndpointRequestContentType(ctx: Context, endpoint: ApiEndpoint): string {
-    return ctx.config.defaultSuccessResponseContentType ?? endpoint?.requestBody?.content[0].type ?? 'application/json';
+    return ctx.config.defaultRequestContentType ?? endpoint?.requestBody?.content[0].type ?? 'application/json';
   }
 
   protected getEndpointSuccessResponseType(ctx: Context, endpoint: ApiEndpoint): string {

--- a/packages/typescript/src/generators/services/angular-services/angular-service-generator.ts
+++ b/packages/typescript/src/generators/services/angular-services/angular-service-generator.ts
@@ -295,9 +295,7 @@ export class DefaultTypeScriptAngularServiceGenerator extends TypeScriptFileGene
                         }, ${options});`;
                       }),
                     endpoint.requestBody
-                      ? s`rb.body(params.body, ${
-                        ts.string(endpoint.requestBody.content[0].type ?? 'application/json')
-                      });`
+                      ? s`rb.body(params.body, ${ts.string(this.getEndpointRequestContentType(ctx, endpoint))});`
                       : null,
                   ],
                   '\n',
@@ -332,14 +330,18 @@ export class DefaultTypeScriptAngularServiceGenerator extends TypeScriptFileGene
     });
   }
 
+  protected getEndpointRequestContentType(ctx: Context, endpoint: ApiEndpoint): string {
+    return ctx.config.defaultSuccessResponseContentType ?? endpoint?.requestBody?.content[0].type ?? 'application/json';
+  }
+
   protected getEndpointSuccessResponseType(ctx: Context, endpoint: ApiEndpoint): string {
     const response = this.getEndpointSuccessResponse(ctx, endpoint);
     if (!response) return '*/*';
 
-    if (!ctx.config.defaultSuccessResponseType) return response.contentOptions[0]?.type ?? '*/*';
+    if (!ctx.config.defaultSuccessResponseContentType) return response.contentOptions[0]?.type ?? '*/*';
 
     return (
-      response.contentOptions.find((x) => x.type === ctx.config.defaultSuccessResponseType)?.type ??
+      response.contentOptions.find((x) => x.type === ctx.config.defaultSuccessResponseContentType)?.type ??
         response.contentOptions[0]?.type ??
         '*/*'
     );

--- a/packages/typescript/src/generators/services/angular-services/models.ts
+++ b/packages/typescript/src/generators/services/angular-services/models.ts
@@ -70,10 +70,16 @@ export type TypeScriptAngularServicesGeneratorConfig = TypeScriptGeneratorConfig
   >;
 
   /**
+   * The default content type which is used for the request. If not defined the first one defined in the OpenApi specification is used.
+   * @default undefined
+   */
+  defaultRequestContentType: Nullable<string>;
+
+  /**
    * The default content type which is used for the success response. If not defined the first one defined in the OpenApi specification is used.
    * @default undefined
    */
-  defaultSuccessResponseType: Nullable<string>;
+  defaultSuccessResponseContentType: Nullable<string>;
 
   /**
    * The possible status codes that any API endpoint can return.
@@ -151,7 +157,7 @@ export const defaultTypeScriptAngularServicesGeneratorConfig: DefaultGenerationP
     403: null,
     500: null,
   },
-  defaultSuccessResponseType: undefined,
+  defaultSuccessResponseContentType: undefined,
   possibleStatusCodes: [
     100,
     101,

--- a/packages/typescript/src/generators/services/angular-services/models.ts
+++ b/packages/typescript/src/generators/services/angular-services/models.ts
@@ -157,6 +157,7 @@ export const defaultTypeScriptAngularServicesGeneratorConfig: DefaultGenerationP
     403: null,
     500: null,
   },
+  defaultRequestContentType: undefined,
   defaultSuccessResponseContentType: undefined,
   possibleStatusCodes: [
     100,


### PR DESCRIPTION
you can specify the default request contenttype because right now always the first one is used