### PR TITLE
reified type parameter from parseDateToQueryString incompatible with Kotlin 2.3

### DIFF
--- a/packages/kotlin/assets/client/okhttp3/ApiClient.kt
+++ b/packages/kotlin/assets/client/okhttp3/ApiClient.kt
@@ -241,7 +241,7 @@ open class ApiClient(@API_CLIENT_PARAMETERS@) {
         else -> value.toString()
     }
 
-    protected inline fun <reified T : Any> parseDateToQueryString(value: T): String {
+    protected fun parseDateToQueryString(value: Any): String {
         /*
         .replace("\"", "") converts the json object string to an actual string for the query parameter.
         The moshi or gson adapter allows a more generic solution instead of trying to use a native


### PR DESCRIPTION
Kotlin 2.3 fails with the following error:

```
ApiClient.kt:239:13 Type argument for reified type parameter 'T' was
inferred to the intersection of ['Temporal' & 'TemporalAdjuster' &
'Comparable<OffsetDateTime! & OffsetTime! & ChronoLocalDateTime<*>! &
ChronoLocalDate! & LocalTime!>' & 'Serializable']. Reification of an
intersection type results in the common supertype being used. This may
lead to subtle issues and an explicit type argument is encouraged.
```

The function was `inline reified` for no reason, as the intersection type's common supertype is `Any`, so reification isn't needed.