### PR TITLE
feat(typescript): add StubHandle support to easy-network-stub generator

### DIFF
--- a/packages/typescript/assets/stubs/easy-network-stub/easy-network-stub.utils.ts
+++ b/packages/typescript/assets/stubs/easy-network-stub/easy-network-stub.utils.ts
@@ -1,6 +1,4 @@
-import type { EasyNetworkStub } from 'easy-network-stub';
-
-import type { ErrorResponse, HttpMethod, RouteResponseCallback } from 'easy-network-stub';
+import type { EasyNetworkStub, ErrorResponse, HttpMethod, RouteResponseCallback, StubHandle } from 'easy-network-stub';
 
 /**
  * Options for the `EasyNetworkStubWrapper`.
@@ -130,8 +128,8 @@ export class EasyNetworkStubWrapper {
     method: HttpMethod,
     route: Route,
     response: RouteResponseCallback<Route, unknown>,
-  ): void {
-    this.wrappedStub.stub<Route>(method, route, async (request) => {
+  ): StubHandle {
+    return this.wrappedStub.stub<Route>(method, route, async (request) => {
       if (this.options.delay > 0) await sleep(this.options.delay);
       return await this.runRequest(method, route, response, request);
     });
@@ -154,9 +152,9 @@ export class EasyNetworkStubWrapper {
     method: HttpMethod,
     route: Route,
     response: RouteResponseCallback<Route, T>,
-  ) => void {
+  ) => StubHandle {
     return <Route extends string>(method: HttpMethod, route: Route, response: RouteResponseCallback<Route, T>) => {
-      this.wrappedStub.stub2<T>()<Route>(method, route, async (request) => {
+      return this.wrappedStub.stub2<T>()<Route>(method, route, async (request) => {
         if (this.options.delay > 0) await sleep(this.options.delay);
         return await this.runRequest(method, route, response, request);
       });
@@ -168,7 +166,7 @@ export class EasyNetworkStubWrapper {
    */
   public reset(): void {
     this._requests = [];
-    this.wrappedStub['_config'].stubs = [];
+    this.wrappedStub.reset();
   }
 
   private async runRequest<Route extends string, T>(

--- a/packages/typescript/deno.json
+++ b/packages/typescript/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@goast/typescript",
-  "version": "0.6.2",
+  "version": "0.7.0",
   "description": "Provides gOAst generators for generating TypeScript code from OpenAPI specifications.",
   "exports": "./mod.ts",
   "publish": {

--- a/packages/typescript/src/generators/services/easy-network-stub/easy-network-stub-generator.ts
+++ b/packages/typescript/src/generators/services/easy-network-stub/easy-network-stub-generator.ts
@@ -98,6 +98,13 @@ export class DefaultTypeScriptEasyNetworkStubGenerator extends TypeScriptFileGen
         ),
         '\n',
         ...ctx.service.endpoints.map((endpoint) =>
+          ts.property<Builder>(this.getEndpointStubHandleFieldName(ctx, endpoint), {
+            accessModifier: 'private',
+            type: s`${ctx.refs.stubHandle()} | undefined`,
+          })
+        ),
+        '\n',
+        ...ctx.service.endpoints.map((endpoint) =>
           ts.property<Builder>(this.getEndpointRequestsPropertyName(ctx, endpoint), {
             readonly: true,
             accessModifier: 'public',
@@ -108,12 +115,16 @@ export class DefaultTypeScriptEasyNetworkStubGenerator extends TypeScriptFileGen
           })
         ),
         ...ctx.service.endpoints.map((endpoint) => this.getEndpointStubMethod(ctx, endpoint)),
+        ...ctx.service.endpoints.map((endpoint) => this.getEndpointUnregisterMethod(ctx, endpoint)),
         ts.method('reset', {
           accessModifier: 'public',
           override: true,
           returnType: ts.refs.void_(),
           body: appendValueGroup(
             [
+              ...ctx.service.endpoints.map((endpoint) =>
+                `this.${this.getEndpointStubHandleFieldName(ctx, endpoint)} = undefined;`
+              ),
               ...ctx.service.endpoints.map((endpoint) =>
                 `this.${this.getEndpointRequestsFieldName(ctx, endpoint)}.length = 0;`
               ),
@@ -156,7 +167,13 @@ export class DefaultTypeScriptEasyNetworkStubGenerator extends TypeScriptFileGen
       returnType: 'this',
       body: appendValueGroup(
         [
-          s`this.stubWrapper.stub2<${requestType}>()(${s.indent`
+          s`if (this.${this.getEndpointStubHandleFieldName(ctx, endpoint)}) {${s.indent`
+              throw new Error('${this.getEndpointStubMethodName(ctx, endpoint)} has already been called. Call ${
+            this.getEndpointUnregisterMethodName(ctx, endpoint)
+          }() or reset() before stubbing again.');`}
+            }`,
+          s`this.${this.getEndpointStubHandleFieldName(ctx, endpoint)} = this.stubWrapper.stub2<${requestType}>()(${s
+            .indent`
               ${ts.string(endpoint.method.toUpperCase())},
               ${this.getStubClassName(ctx)}.${this.getEndpointPathPropertyName(ctx, endpoint)},
               async (request) => {${s.indent`
@@ -197,12 +214,34 @@ export class DefaultTypeScriptEasyNetworkStubGenerator extends TypeScriptFileGen
     return toCasing(endpoint.name + '_Requests', adjustCasing(ctx.config.propertyNameCasing, { prefix: '_' }));
   }
 
+  protected getEndpointStubHandleFieldName(ctx: Context, endpoint: ApiEndpoint): string {
+    return toCasing('stub_' + endpoint.name + '_Handle', adjustCasing(ctx.config.propertyNameCasing, { prefix: '_' }));
+  }
+
   protected getEndpointRequestsPropertyName(ctx: Context, endpoint: ApiEndpoint): string {
     return toCasing(endpoint.name + '_Requests', ctx.config.propertyNameCasing);
   }
 
   protected getEndpointStubMethodName(ctx: Context, endpoint: ApiEndpoint): string {
     return toCasing('stub_' + endpoint.name, ctx.config.functionNameCasing);
+  }
+
+  protected getEndpointUnregisterMethodName(ctx: Context, endpoint: ApiEndpoint): string {
+    return toCasing('unregister_stub_' + endpoint.name, ctx.config.functionNameCasing);
+  }
+
+  protected getEndpointUnregisterMethod(ctx: Context, endpoint: ApiEndpoint): ts.Method<Builder> {
+    return ts.method(this.getEndpointUnregisterMethodName(ctx, endpoint), {
+      accessModifier: 'public',
+      returnType: ts.refs.void_(),
+      body: appendValueGroup(
+        [
+          `this.${this.getEndpointStubHandleFieldName(ctx, endpoint)}?.unregister();`,
+          `this.${this.getEndpointStubHandleFieldName(ctx, endpoint)} = undefined;`,
+        ],
+        '\n',
+      ),
+    });
   }
 
   protected getStubRoute(ctx: Context, endpoint: ApiEndpoint): string {

--- a/packages/typescript/src/generators/services/easy-network-stub/refs.ts
+++ b/packages/typescript/src/generators/services/easy-network-stub/refs.ts
@@ -42,6 +42,6 @@ export function getReferenceFactories(options: TypeScriptEasyNetworkStubsGenerat
       importType: 'type-import',
     }),
     createEasyNetworkStubGroup: ts.reference.genericFactory<2>('createEasyNetworkStubGroup', easyNetworkStubUtilsPath),
-    stubHandle: ts.reference.factory('StubHandle', easyNetworkStubUtilsPath, { importType: 'type-import' }),
+    stubHandle: ts.reference.factory('StubHandle', 'easy-network-stub', { importType: 'type-import' }),
   };
 }

--- a/packages/typescript/src/generators/services/easy-network-stub/refs.ts
+++ b/packages/typescript/src/generators/services/easy-network-stub/refs.ts
@@ -14,6 +14,7 @@ export function getReferenceFactories(options: TypeScriptEasyNetworkStubsGenerat
   easyNetworkStubBase: ts.ModuleReferenceFactory;
   easyNetworkStubGroup: ts.GenericModuleReferenceFactory<2>;
   createEasyNetworkStubGroup: ts.GenericModuleReferenceFactory<2>;
+  stubHandle: ts.ModuleReferenceFactory;
 } {
   const utilsDirPath = resolve(options.outputDir, options.utilsDir);
   const easyNetworkStubUtilsPath = join(utilsDirPath, 'easy-network-stub.utils.ts');
@@ -41,5 +42,6 @@ export function getReferenceFactories(options: TypeScriptEasyNetworkStubsGenerat
       importType: 'type-import',
     }),
     createEasyNetworkStubGroup: ts.reference.genericFactory<2>('createEasyNetworkStubGroup', easyNetworkStubUtilsPath),
+    stubHandle: ts.reference.factory('StubHandle', easyNetworkStubUtilsPath, { importType: 'type-import' }),
   };
 }


### PR DESCRIPTION
- Update stub/stub2 wrapper to return StubHandle from easy-network-stub
- Re-export StubHandle type from utils
- Generate private _stubXxxHandle field for each endpoint
- Assign stub2() return value to handle field in stub methods
- Add unregisterStubXxx() public method per endpoint
- Throw if stub method is called twice without unregister/reset
- Remove handles in reset()