### PR TITLE
feat(kotlin): add Spring Boot 4 output support behind springBootVersion option

### DIFF
--- a/packages/kotlin/assets/client/okhttp3/ApiClient.kt
+++ b/packages/kotlin/assets/client/okhttp3/ApiClient.kt
@@ -14,7 +14,6 @@ import okhttp3.RequestBody
 import okhttp3.RequestBody.Companion.asRequestBody
 import okhttp3.RequestBody.Companion.toRequestBody
 import okhttp3.ResponseBody
-import okhttp3.internal.EMPTY_REQUEST
 import java.io.File
 import java.net.URLConnection
 import java.time.LocalDate
@@ -106,7 +105,7 @@ open class ApiClient(@API_CLIENT_PARAMETERS@) {
 
             mediaType == null || mediaType.startsWith("application/") && mediaType.endsWith("json") ->
                 if (content == null) {
-                    EMPTY_REQUEST
+                    ByteArray(0).toRequestBody(null)
                 } else {
                     objectMapper.writeValueAsString(content)
                         .toRequestBody((mediaType ?: JsonMediaType).toMediaTypeOrNull())

--- a/packages/kotlin/deno.json
+++ b/packages/kotlin/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@goast/kotlin",
-  "version": "0.5.9",
+  "version": "0.5.10",
   "description": "Provides gOAst generators for generating Kotlin code from OpenAPI specifications.",
   "exports": "./mod.ts",
   "publish": {

--- a/packages/kotlin/src/ast/references/jackson.test.ts
+++ b/packages/kotlin/src/ast/references/jackson.test.ts
@@ -1,0 +1,63 @@
+import { expect } from '@std/expect/expect';
+import { describe, it } from '@std/testing/bdd';
+
+import * as jackson from './jackson.ts';
+
+describe('jackson references', () => {
+  describe('springBootVersion-dependent packages', () => {
+    const movedRefs: { name: string; factory: (v?: 3 | 4) => { packageName: string | null } }[] = [
+      { name: 'objectMapper', factory: jackson.objectMapper },
+      { name: 'serializationFeature', factory: jackson.serializationFeature },
+      { name: 'deserializationFeature', factory: jackson.deserializationFeature },
+      { name: 'jacksonObjectMapper', factory: jackson.jacksonObjectMapper },
+    ];
+
+    const expectedV3: Record<string, string> = {
+      objectMapper: 'com.fasterxml.jackson.databind',
+      serializationFeature: 'com.fasterxml.jackson.databind',
+      deserializationFeature: 'com.fasterxml.jackson.databind',
+      jacksonObjectMapper: 'com.fasterxml.jackson.module.kotlin',
+    };
+
+    const expectedV4: Record<string, string> = {
+      objectMapper: 'tools.jackson.databind',
+      serializationFeature: 'tools.jackson.databind',
+      deserializationFeature: 'tools.jackson.databind',
+      jacksonObjectMapper: 'tools.jackson.module.kotlin',
+    };
+
+    for (const { name, factory } of movedRefs) {
+      it(`defaults ${name} to the Jackson 2 (Spring Boot 3) package`, () => {
+        expect(factory().packageName).toBe(expectedV3[name]);
+      });
+
+      it(`resolves ${name} to the Jackson 2 package for Spring Boot 3`, () => {
+        expect(factory(3).packageName).toBe(expectedV3[name]);
+      });
+
+      it(`resolves ${name} to the Jackson 3 (tools.jackson) package for Spring Boot 4`, () => {
+        expect(factory(4).packageName).toBe(expectedV4[name]);
+      });
+    }
+  });
+
+  describe('annotations stay on com.fasterxml.jackson.annotation', () => {
+    const annotationRefs = [
+      jackson.jsonProperty,
+      jackson.jsonInclude,
+      jackson.jsonTypeInfo,
+      jackson.jsonSubTypes,
+      jackson.jsonIgnore,
+      jackson.jsonAnySetter,
+      jackson.jsonAnyGetter,
+      jackson.jsonClassDescription,
+      jackson.jsonPropertyDescription,
+    ];
+
+    for (const factory of annotationRefs) {
+      it(`keeps ${factory.refName} on com.fasterxml.jackson.annotation`, () => {
+        expect(factory().packageName).toBe('com.fasterxml.jackson.annotation');
+      });
+    }
+  });
+});

--- a/packages/kotlin/src/ast/references/jackson.ts
+++ b/packages/kotlin/src/ast/references/jackson.ts
@@ -1,4 +1,16 @@
-import { ktReference, type KtReferenceFactory } from '../nodes/reference.ts';
+import type { SourceBuilder } from '@goast/core';
+
+import type { SpringBootVersion } from '../../config.ts';
+import { type KtReference, ktReference, type KtReferenceFactory } from '../nodes/reference.ts';
+
+/**
+ * Resolves a Jackson package name for the targeted Spring Boot version.
+ *
+ * Jackson 3 (the default in Spring Boot 4) moved every package **except annotations** from
+ * `com.fasterxml.jackson.*` to `tools.jackson.*`. Annotations stay on `com.fasterxml.jackson.annotation`.
+ */
+const jacksonPackage = (subPackage: string, springBootVersion: SpringBootVersion): string =>
+  `${springBootVersion === 4 ? 'tools.jackson' : 'com.fasterxml.jackson'}.${subPackage}`;
 
 // com.fasterxml.jackson.annotation
 export const jsonTypeInfo: KtReferenceFactory = ktReference.factory('JsonTypeInfo', 'com.fasterxml.jackson.annotation');
@@ -23,22 +35,25 @@ export const jsonAnyGetter: KtReferenceFactory = ktReference.factory(
   'com.fasterxml.jackson.annotation',
 );
 
-// com.fasterxml.jackson.databind
-export const objectMapper: KtReferenceFactory = ktReference.factory(
-  'ObjectMapper',
-  'com.fasterxml.jackson.databind',
-);
-export const serializationFeature: KtReferenceFactory = ktReference.factory(
-  'SerializationFeature',
-  'com.fasterxml.jackson.databind',
-);
-export const deserializationFeature: KtReferenceFactory = ktReference.factory(
-  'DeserializationFeature',
-  'com.fasterxml.jackson.databind',
-);
+// com.fasterxml.jackson.databind (Jackson 2) / tools.jackson.databind (Jackson 3, Spring Boot 4)
+export const objectMapper = <TBuilder extends SourceBuilder>(
+  springBootVersion: SpringBootVersion = 3,
+): KtReference<TBuilder> => ktReference<TBuilder>('ObjectMapper', jacksonPackage('databind', springBootVersion));
+export const serializationFeature = <TBuilder extends SourceBuilder>(
+  springBootVersion: SpringBootVersion = 3,
+): KtReference<TBuilder> =>
+  ktReference<TBuilder>('SerializationFeature', jacksonPackage('databind', springBootVersion));
+export const deserializationFeature = <TBuilder extends SourceBuilder>(
+  springBootVersion: SpringBootVersion = 3,
+): KtReference<TBuilder> =>
+  ktReference<TBuilder>('DeserializationFeature', jacksonPackage('databind', springBootVersion));
 
-// com.fasterxml.jackson.module.kotlin
-export const jacksonObjectMapper: KtReferenceFactory = ktReference.factory(
-  'jacksonObjectMapper',
-  'com.fasterxml.jackson.module.kotlin',
-);
+// com.fasterxml.jackson.module.kotlin (Jackson 2) / tools.jackson.module.kotlin (Jackson 3, Spring Boot 4)
+export const jacksonObjectMapper = <TBuilder extends SourceBuilder>(
+  springBootVersion: SpringBootVersion = 3,
+): KtReference<TBuilder> =>
+  ktReference<TBuilder>('jacksonObjectMapper', jacksonPackage('module.kotlin', springBootVersion));
+export const jacksonMapperBuilder = <TBuilder extends SourceBuilder>(
+  springBootVersion: SpringBootVersion = 3,
+): KtReference<TBuilder> =>
+  ktReference<TBuilder>('jacksonMapperBuilder', jacksonPackage('module.kotlin', springBootVersion));

--- a/packages/kotlin/src/config.ts
+++ b/packages/kotlin/src/config.ts
@@ -5,6 +5,9 @@ import type {
   StringCasingWithOptions,
 } from '@goast/core';
 
+/** The Spring Boot major version the Kotlin generators target. */
+export type SpringBootVersion = 3 | 4;
+
 export type KotlinGeneratorConfig = OpenApiGeneratorConfig & {
   typeNameCasing: StringCasing | StringCasingWithOptions;
   parameterNameCasing: StringCasing | StringCasingWithOptions;
@@ -20,6 +23,15 @@ export type KotlinGeneratorConfig = OpenApiGeneratorConfig & {
    * @default false
    */
   includeSourceInDocs: boolean;
+
+  /**
+   * The targeted Spring Boot major version. Controls Jackson package names, Kotlin generic bounds, and
+   * `ResponseEntity` nullability so the generated code compiles against the matching framework generation.
+   * - `3`: Spring Boot 3 (Spring Framework 6 / Jackson 2). Produces output identical to previous versions.
+   * - `4`: Spring Boot 4 (Spring Framework 7 / Jackson 3 / JSpecify null-safety).
+   * @default 3
+   */
+  springBootVersion: SpringBootVersion;
 };
 
 export const defaultKotlinGeneratorConfig: DefaultGenerationProviderConfig<KotlinGeneratorConfig> = {
@@ -45,4 +57,5 @@ export const defaultKotlinGeneratorConfig: DefaultGenerationProviderConfig<Kotli
     'kotlin.jvm.*',
   ],
   includeSourceInDocs: false,
+  springBootVersion: 3,
 };

--- a/packages/kotlin/src/generators/services/okhttp3-clients/okhttp3-client-generator.ts
+++ b/packages/kotlin/src/generators/services/okhttp3-clients/okhttp3-client-generator.ts
@@ -66,14 +66,18 @@ export class DefaultKotlinOkHttp3Generator extends KotlinFileGenerator<Context, 
       extends: ctx.refs.apiClient(),
       primaryConstructor: kt.constructor(
         [
-          serializerAsParameter ? kt.parameter('objectMapper', kt.refs.jackson.objectMapper()) : null,
+          serializerAsParameter
+            ? kt.parameter('objectMapper', kt.refs.jackson.objectMapper(ctx.config.springBootVersion))
+            : null,
           kt.parameter('basePath', kt.refs.string(), { default: 'defaultBasePath' }),
           kt.parameter('client', kt.refs.okhttp3.okHttpClient(), {
             default: 'defaultClient',
           }),
-          serializerAsParameter ? null : kt.parameter('objectMapper', kt.refs.jackson.objectMapper(), {
-            default: kt.call([ctx.refs.serializer(), 'jacksonObjectMapper']),
-          }),
+          serializerAsParameter
+            ? null
+            : kt.parameter('objectMapper', kt.refs.jackson.objectMapper(ctx.config.springBootVersion), {
+              default: kt.call([ctx.refs.serializer(), 'jacksonObjectMapper']),
+            }),
         ],
         null,
         {

--- a/packages/kotlin/src/generators/services/okhttp3-clients/okhttp3-clients-generator.ts
+++ b/packages/kotlin/src/generators/services/okhttp3-clients/okhttp3-clients-generator.ts
@@ -131,6 +131,14 @@ export class KotlinOkHttp3ClientsGenerator extends OpenApiServicesGenerationProv
             : 'val baseUrl: String, val client: Factory = defaultClient, val objectMapper: ObjectMapper = Serializer.jacksonObjectMapper',
         );
       }
+      if (ctx.config.springBootVersion === 4) {
+        // Jackson 3 (Spring Boot 4) moved every package except annotations from
+        // `com.fasterxml.jackson.*` to `tools.jackson.*`. Rewrite the imports in the copied assets to match.
+        fileContent = fileContent.replace(
+          /\bcom\.fasterxml\.jackson\.(core|databind|module|datatype|dataformat)\b/g,
+          'tools.jackson.$1',
+        );
+      }
       writeGeneratedFile(ctx.config, targetPath, fileContent);
     }
 
@@ -140,15 +148,26 @@ export class KotlinOkHttp3ClientsGenerator extends OpenApiServicesGenerationProv
     ) {
       const filePath = resolve(targetDir, 'Serializer.kt');
       console.log(`Generating Serializer to ${filePath}...`);
+      const springBootVersion = ctx.config.springBootVersion;
+      const jsonIncludeMember = toCasing(ctx.config.serializerJsonInclude, 'snake');
+      const defaultFactory: AppendValue<KotlinFileBuilder> = springBootVersion === 4
+        // Jackson 3's ObjectMapper is immutable; configuration moved to the (Kotlin) mapper builder.
+        ? s`${kt.refs.jackson.jacksonMapperBuilder(springBootVersion)}()${s.indent`
+            .findAndAddModules()
+            .changeDefaultPropertyInclusion { it.withValueInclusion(${kt.refs.jackson.jsonInclude()}.Include.${jsonIncludeMember}).withContentInclusion(${kt.refs.jackson.jsonInclude()}.Include.${jsonIncludeMember}) }
+            .configure(${kt.refs.jackson.serializationFeature(springBootVersion)}.WRITE_DATES_AS_TIMESTAMPS, false)
+            .configure(${kt.refs.jackson.deserializationFeature(springBootVersion)}.FAIL_ON_UNKNOWN_PROPERTIES, false)
+            .build()`}`
+        : s`${kt.refs.jackson.jacksonObjectMapper(springBootVersion)}()${s.indent`
+            .findAndRegisterModules()
+            .setSerializationInclusion(${kt.refs.jackson.jsonInclude()}.Include.${jsonIncludeMember})
+            .configure(${kt.refs.jackson.serializationFeature(springBootVersion)}.WRITE_DATES_AS_TIMESTAMPS, false)
+            .configure(${
+          kt.refs.jackson.deserializationFeature(springBootVersion)
+        }.FAIL_ON_UNKNOWN_PROPERTIES, false)`}`;
       const factory: AppendValue<KotlinFileBuilder> = typeof ctx.config.serializer === 'object'
         ? ctx.config.serializer.factory
-        : s`${kt.refs.jackson.jacksonObjectMapper()}()${s.indent`
-            .findAndRegisterModules()
-            .setSerializationInclusion(${kt.refs.jackson.jsonInclude()}.Include.${
-          toCasing(ctx.config.serializerJsonInclude, 'snake')
-        })
-            .configure(${kt.refs.jackson.serializationFeature()}.WRITE_DATES_AS_TIMESTAMPS, false)
-            .configure(${kt.refs.jackson.deserializationFeature()}.FAIL_ON_UNKNOWN_PROPERTIES, false)`}`;
+        : defaultFactory;
 
       const builder = new KotlinFileBuilder(ctx.infrastructurePackageName, ctx.config);
       builder.append(
@@ -156,7 +175,7 @@ export class KotlinOkHttp3ClientsGenerator extends OpenApiServicesGenerationProv
           name: 'Serializer',
           members: [
             kt.property('jacksonObjectMapper', {
-              type: kt.refs.jackson.objectMapper(),
+              type: kt.refs.jackson.objectMapper(ctx.config.springBootVersion),
               mutable: false,
               default: kt.call('run', [kt.lambda([], factory)]),
             }),

--- a/packages/kotlin/src/generators/services/spring-controllers/spring-controller-generator.ts
+++ b/packages/kotlin/src/generators/services/spring-controllers/spring-controller-generator.ts
@@ -479,12 +479,16 @@ export class DefaultKotlinSpringControllerGenerator extends KotlinFileGenerator<
   ): kt.Class<Builder> {
     const { endpoint } = args;
     const name = this.getApiResponseEntityName(ctx, { endpoint });
+    // Spring 7's `ResponseEntity<T>` carries an `Any` upper bound (JSpecify), so the subclass must bound `T`.
+    // The body parameter is then made nullable (`T?`) to keep null-body ("no response body") responses legal
+    // while staying wire-identical, since Spring's super constructor accepts a `@Nullable T body`.
+    const springBoot4 = ctx.config.springBootVersion === 4;
     return kt.class(name, {
       doc: kt.doc(`Response entity for ${endpoint.name}.`),
-      generics: [kt.genericParameter('T')],
+      generics: [kt.genericParameter('T', springBoot4 ? { constraint: kt.refs.any() } : undefined)],
       primaryConstructor: kt.constructor(
         [
-          kt.parameter.class('body', kt.reference('T')),
+          kt.parameter.class('body', kt.reference('T', null, springBoot4 ? { nullable: true } : undefined)),
           kt.parameter.class('rawStatus', kt.refs.int()),
           kt.parameter.class(
             'headers',
@@ -549,7 +553,11 @@ export class DefaultKotlinSpringControllerGenerator extends KotlinFileGenerator<
                   null,
                   {
                     generics: [
-                      hasResponseBody ? responseType : kt.refs.unit({ nullable: true }),
+                      hasResponseBody
+                        ? responseType
+                        // `Unit?` violates the `T : Any` bound under Spring Boot 4; the `null` body argument
+                        // below stays (now legal because the subclass body parameter is nullable).
+                        : (springBoot4 ? kt.refs.unit() : kt.refs.unit({ nullable: true })),
                     ],
                   },
                 ),
@@ -888,7 +896,9 @@ export class DefaultKotlinSpringControllerGenerator extends KotlinFileGenerator<
     } else if (responseSchemas.length === 0) {
       return kt.refs.unit();
     } else {
-      return kt.refs.any({ nullable: true });
+      // Under Spring Boot 4, this type flows into `ResponseEntity<T : Any>` (e.g. the delegate default methods),
+      // so the ambiguous/unknown-body fallback must be non-null `Any` rather than `Any?`.
+      return ctx.config.springBootVersion === 4 ? kt.refs.any() : kt.refs.any({ nullable: true });
     }
   }
 

--- a/packages/kotlin/src/generators/services/spring-reactive-web-clients/spring-reactive-web-client-generator.ts
+++ b/packages/kotlin/src/generators/services/spring-reactive-web-clients/spring-reactive-web-client-generator.ts
@@ -146,7 +146,10 @@ export class DefaultKotlinSpringReactiveWebClientGenerator extends KotlinFileGen
     return kt.function(functionName, {
       doc: kt.doc(this.getEndpointDocDescription(ctx, { endpoint })),
       suspend: true,
-      generics: [kt.genericParameter('T')],
+      // Spring 7's `WebClient.exchangeToMono` is `<V : Any>`, so the `<T>` overloads need an `Any` bound to infer.
+      generics: [
+        kt.genericParameter('T', ctx.config.springBootVersion === 4 ? { constraint: kt.refs.any() } : undefined),
+      ],
       receiverType: kt.refs.springReactive.webClient(),
       parameters: [
         ...parameters.map((parameter) =>

--- a/packages/kotlin/tests/.verify/openapi-services/okhttp-3-clients-spring-boot-3.expect.txt
+++ b/packages/kotlin/tests/.verify/openapi-services/okhttp-3-clients-spring-boot-3.expect.txt
@@ -1,0 +1,1103 @@
+┌──────────────────────────────────────┐
+│ state                                │
+├──────────────────────────────────────┤
+{
+  kotlin: {
+    clients: {
+      'service-1': {
+        __source__: 'tag:Pets',
+        packageName: 'com.openapi.generated.api.client',
+        typeName: 'PetsApiClient'
+      }
+    },
+    models: {
+      'schema-1': {
+        __source__: '<root>/test/openapi-files/v3/service-endpoints.yml#/paths//pets/get/responses/200/content/application/json/schema',
+        type: KtReference {
+          classReference: false,
+          generics: [
+            KtReference {
+              classReference: false,
+              generics: [],
+              inject: {},
+              name: 'Pet',
+              nullable: false,
+              packageName: 'com.openapi.generated.model',
+              subReference: null
+            }
+          ],
+          inject: {},
+          name: 'List',
+          nullable: false,
+          packageName: 'kotlin.collections',
+          subReference: null
+        }
+      },
+      'schema-10': {
+        __source__: '<root>/test/openapi-files/v3/service-endpoints.yml#/components/schemas/Pet',
+        type: KtReference {
+          classReference: false,
+          generics: [],
+          inject: {},
+          name: 'Pet',
+          nullable: false,
+          packageName: 'com.openapi.generated.model',
+          subReference: null
+        }
+      },
+      'schema-11': {
+        __source__: '<root>/test/openapi-files/v3/service-endpoints.yml#/paths//pets/{id}/delete/parameters/0/schema',
+        type: KtReference {
+          classReference: false,
+          generics: [],
+          inject: {},
+          name: 'String',
+          nullable: false,
+          packageName: 'kotlin',
+          subReference: null
+        }
+      },
+      'schema-12': {
+        __source__: '<root>/test/openapi-files/v3/service-endpoints.yml#/components/schemas/Pet',
+        type: KtReference {
+          classReference: false,
+          generics: [],
+          inject: {},
+          name: 'Pet',
+          nullable: false,
+          packageName: 'com.openapi.generated.model',
+          subReference: null
+        }
+      },
+      'schema-13': {
+        __source__: '<root>/test/openapi-files/v3/service-endpoints.yml#/components/schemas/Owner',
+        type: KtReference {
+          classReference: false,
+          generics: [],
+          inject: {},
+          name: 'Owner',
+          nullable: false,
+          packageName: 'com.openapi.generated.model',
+          subReference: null
+        }
+      },
+      'schema-14': {
+        __source__: '<root>/test/openapi-files/v3/service-endpoints.yml#/components/schemas/Owner',
+        type: KtReference {
+          classReference: false,
+          generics: [],
+          inject: {},
+          name: 'Owner',
+          nullable: false,
+          packageName: 'com.openapi.generated.model',
+          subReference: null
+        }
+      },
+      'schema-15': {
+        __source__: '<root>/test/openapi-files/v3/service-endpoints.yml#/components/schemas/Owner/properties/name',
+        type: KtReference {
+          classReference: false,
+          generics: [],
+          inject: {},
+          name: 'String',
+          nullable: false,
+          packageName: 'kotlin',
+          subReference: null
+        }
+      },
+      'schema-2': {
+        __source__: '<root>/test/openapi-files/v3/service-endpoints.yml#/components/schemas/Pet',
+        type: KtReference {
+          classReference: false,
+          generics: [],
+          inject: {},
+          name: 'Pet',
+          nullable: false,
+          packageName: 'com.openapi.generated.model',
+          subReference: null
+        }
+      },
+      'schema-3': {
+        __source__: '<root>/test/openapi-files/v3/service-endpoints.yml#/components/schemas/Pet',
+        type: KtReference {
+          classReference: false,
+          generics: [],
+          inject: {},
+          name: 'Pet',
+          nullable: false,
+          packageName: 'com.openapi.generated.model',
+          subReference: null
+        }
+      },
+      'schema-4': {
+        __source__: '<root>/test/openapi-files/v3/service-endpoints.yml#/components/schemas/Pet/properties/id',
+        type: KtReference {
+          classReference: false,
+          generics: [],
+          inject: {},
+          name: 'String',
+          nullable: false,
+          packageName: 'kotlin',
+          subReference: null
+        }
+      },
+      'schema-5': {
+        __source__: '<root>/test/openapi-files/v3/service-endpoints.yml#/components/schemas/Pet/properties/name',
+        type: KtReference {
+          classReference: false,
+          generics: [],
+          inject: {},
+          name: 'String',
+          nullable: false,
+          packageName: 'kotlin',
+          subReference: null
+        }
+      },
+      'schema-6': {
+        __source__: '<root>/test/openapi-files/v3/service-endpoints.yml#/components/schemas/Pet/properties/tag',
+        type: KtReference {
+          classReference: false,
+          generics: [],
+          inject: {},
+          name: 'String',
+          nullable: false,
+          packageName: 'kotlin',
+          subReference: null
+        }
+      },
+      'schema-7': {
+        __source__: '<root>/test/openapi-files/v3/service-endpoints.yml#/components/schemas/Pet',
+        type: KtReference {
+          classReference: false,
+          generics: [],
+          inject: {},
+          name: 'Pet',
+          nullable: false,
+          packageName: 'com.openapi.generated.model',
+          subReference: null
+        }
+      },
+      'schema-8': {
+        __source__: '<root>/test/openapi-files/v3/service-endpoints.yml#/components/schemas/Pet',
+        type: KtReference {
+          classReference: false,
+          generics: [],
+          inject: {},
+          name: 'Pet',
+          nullable: false,
+          packageName: 'com.openapi.generated.model',
+          subReference: null
+        }
+      },
+      'schema-9': {
+        __source__: '<root>/test/openapi-files/v3/service-endpoints.yml#/paths//pets/{id}/get/parameters/0/schema',
+        type: KtReference {
+          classReference: false,
+          generics: [],
+          inject: {},
+          name: 'String',
+          nullable: false,
+          packageName: 'kotlin',
+          subReference: null
+        }
+      }
+    }
+  }
+}
+└──────────────────────────────────────┘
+
+┌────────────────────────────────────────┐
+│ out/com/openapi/generated/model/Pet.kt │
+├────────────────────────────────────────┤
+package com.openapi.generated.model
+
+import com.fasterxml.jackson.annotation.JsonProperty
+import io.swagger.v3.oas.annotations.media.Schema
+
+data class Pet(
+    @Schema(required = true)
+    @param:JsonProperty("id", required = true)
+    @get:JsonProperty("id", required = true)
+    val id: String,
+
+    @Schema(required = true)
+    @param:JsonProperty("name", required = true)
+    @get:JsonProperty("name", required = true)
+    val name: String,
+
+    @Schema
+    @param:JsonProperty("tag")
+    @get:JsonProperty("tag")
+    val tag: String? = null
+)
+
+└────────────────────────────────────────┘
+
+┌──────────────────────────────────────────┐
+│ out/com/openapi/generated/model/Owner.kt │
+├──────────────────────────────────────────┤
+package com.openapi.generated.model
+
+import com.fasterxml.jackson.annotation.JsonProperty
+import io.swagger.v3.oas.annotations.media.Schema
+
+data class Owner(
+    @Schema(required = true)
+    @param:JsonProperty("name", required = true)
+    @get:JsonProperty("name", required = true)
+    val name: String
+)
+
+└──────────────────────────────────────────┘
+
+┌───────────────────────────────────────────────────────┐
+│ out/com/openapi/generated/api/client/PetsApiClient.kt │
+├───────────────────────────────────────────────────────┤
+package com.openapi.generated.api.client
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.openapi.generated.api.client.infrastructure.ApiClient
+import com.openapi.generated.api.client.infrastructure.ApiResponse
+import com.openapi.generated.api.client.infrastructure.ClientError
+import com.openapi.generated.api.client.infrastructure.ClientException
+import com.openapi.generated.api.client.infrastructure.MultiValueMap
+import com.openapi.generated.api.client.infrastructure.RequestConfig
+import com.openapi.generated.api.client.infrastructure.RequestMethod
+import com.openapi.generated.api.client.infrastructure.ResponseType
+import com.openapi.generated.api.client.infrastructure.Serializer
+import com.openapi.generated.api.client.infrastructure.ServerError
+import com.openapi.generated.api.client.infrastructure.ServerException
+import com.openapi.generated.api.client.infrastructure.Success
+import com.openapi.generated.model.Pet
+import okhttp3.Call.Factory
+import okhttp3.HttpUrl
+import java.io.IOException
+
+class PetsApiClient(
+    basePath: String = defaultBasePath,
+    client: Factory = defaultClient,
+    objectMapper: ObjectMapper = Serializer.jacksonObjectMapper
+) : ApiClient(basePath, objectMapper, client) {
+    companion object {
+        @JvmStatic
+        val defaultBasePath: String by lazy {
+            System.getProperties().getProperty(ApiClient.baseUrlKey, "/")
+        }
+    }
+
+    /**
+     * @throws IllegalStateException If the request is not correctly configured
+     * @throws IOException Rethrows the OkHttp execute method exception
+     * @throws UnsupportedOperationException If the API returns an informational or redirection response
+     * @throws ClientException If the API returns a client error response
+     * @throws ServerException If the API returns a server error response
+     */
+    @Throws(
+        IllegalStateException::class,
+        IOException::class,
+        UnsupportedOperationException::class,
+        ClientException::class,
+        ServerException::class
+    )
+    fun listPets(): List<Pet> {
+        val localVarResponse = listPetsWithHttpInfo()
+
+        return when (localVarResponse.responseType) {
+            ResponseType.Success -> (localVarResponse as Success<*>).data as List<Pet>
+            ResponseType.Informational -> throw UnsupportedOperationException("Client does not support Informational responses.")
+            ResponseType.Redirection -> throw UnsupportedOperationException("Client does not support Redirection responses.")
+            ResponseType.ClientError -> {
+                val localVarError = localVarResponse as ClientError<*>
+                throw ClientException(
+                    "Client error : ${localVarError.statusCode} ${localVarError.message.orEmpty()}",
+                    localVarError.statusCode,
+                    localVarResponse
+                )
+            }
+
+            ResponseType.ServerError -> {
+                val localVarError = localVarResponse as ServerError<*>
+                throw ServerException(
+                    "Server error : ${localVarError.statusCode} ${localVarError.message.orEmpty()}",
+                    localVarError.statusCode,
+                    localVarResponse
+                )
+            }
+        }
+    }
+
+    /**
+     * @throws IllegalStateException If the request is not correctly configured
+     * @throws IOException Rethrows the OkHttp execute method exception
+     */
+    @Throws(IllegalStateException::class, IOException::class)
+    fun listPetsWithHttpInfo(): ApiResponse<List<Pet>?> {
+        val localVariableConfig = listPetsRequestConfig()
+        return request<Unit, List<Pet>>(localVariableConfig)
+    }
+
+    /**
+     * To obtain the request config of the operation listPets
+     */
+    private fun listPetsRequestConfig(): RequestConfig<Unit> {
+        val localVariableQuery: MultiValueMap = mutableMapOf<String, List<String>>()
+        val localVariableHeaders: MutableMap<String, String> = mutableMapOf()
+        return RequestConfig(
+            method = RequestMethod.GET,
+            path = "/pets",
+            query = localVariableQuery,
+            headers = localVariableHeaders,
+            requiresAuthentication = false
+        )
+    }
+
+    /**
+     * @throws IllegalStateException If the request is not correctly configured
+     * @throws IOException Rethrows the OkHttp execute method exception
+     * @throws UnsupportedOperationException If the API returns an informational or redirection response
+     * @throws ClientException If the API returns a client error response
+     * @throws ServerException If the API returns a server error response
+     */
+    @Throws(
+        IllegalStateException::class,
+        IOException::class,
+        UnsupportedOperationException::class,
+        ClientException::class,
+        ServerException::class
+    )
+    fun createPet(pet: Pet): Pet {
+        val localVarResponse = createPetWithHttpInfo(pet)
+
+        return when (localVarResponse.responseType) {
+            ResponseType.Success -> (localVarResponse as Success<*>).data as Pet
+            ResponseType.Informational -> throw UnsupportedOperationException("Client does not support Informational responses.")
+            ResponseType.Redirection -> throw UnsupportedOperationException("Client does not support Redirection responses.")
+            ResponseType.ClientError -> {
+                val localVarError = localVarResponse as ClientError<*>
+                throw ClientException(
+                    "Client error : ${localVarError.statusCode} ${localVarError.message.orEmpty()}",
+                    localVarError.statusCode,
+                    localVarResponse
+                )
+            }
+
+            ResponseType.ServerError -> {
+                val localVarError = localVarResponse as ServerError<*>
+                throw ServerException(
+                    "Server error : ${localVarError.statusCode} ${localVarError.message.orEmpty()}",
+                    localVarError.statusCode,
+                    localVarResponse
+                )
+            }
+        }
+    }
+
+    /**
+     * @throws IllegalStateException If the request is not correctly configured
+     * @throws IOException Rethrows the OkHttp execute method exception
+     */
+    @Throws(IllegalStateException::class, IOException::class)
+    fun createPetWithHttpInfo(pet: Pet): ApiResponse<Pet?> {
+        val localVariableConfig = createPetRequestConfig(pet)
+        return request<Pet, Pet>(localVariableConfig)
+    }
+
+    /**
+     * To obtain the request config of the operation createPet
+     */
+    private fun createPetRequestConfig(pet: Pet): RequestConfig<Pet> {
+        val localVariableBody = pet
+        val localVariableQuery: MultiValueMap = mutableMapOf<String, List<String>>()
+        val localVariableHeaders: MutableMap<String, String> = mutableMapOf()
+        localVariableHeaders["Content-Type"] = "application/json"
+        return RequestConfig(
+            method = RequestMethod.POST,
+            path = "/pets",
+            query = localVariableQuery,
+            headers = localVariableHeaders,
+            requiresAuthentication = false,
+            body = localVariableBody
+        )
+    }
+
+    /**
+     * @throws IllegalStateException If the request is not correctly configured
+     * @throws IOException Rethrows the OkHttp execute method exception
+     * @throws UnsupportedOperationException If the API returns an informational or redirection response
+     * @throws ClientException If the API returns a client error response
+     * @throws ServerException If the API returns a server error response
+     */
+    @Throws(
+        IllegalStateException::class,
+        IOException::class,
+        UnsupportedOperationException::class,
+        ClientException::class,
+        ServerException::class
+    )
+    fun getPet(id: String): Pet {
+        val localVarResponse = getPetWithHttpInfo(id)
+
+        return when (localVarResponse.responseType) {
+            ResponseType.Success -> (localVarResponse as Success<*>).data as Pet
+            ResponseType.Informational -> throw UnsupportedOperationException("Client does not support Informational responses.")
+            ResponseType.Redirection -> throw UnsupportedOperationException("Client does not support Redirection responses.")
+            ResponseType.ClientError -> {
+                val localVarError = localVarResponse as ClientError<*>
+                throw ClientException(
+                    "Client error : ${localVarError.statusCode} ${localVarError.message.orEmpty()}",
+                    localVarError.statusCode,
+                    localVarResponse
+                )
+            }
+
+            ResponseType.ServerError -> {
+                val localVarError = localVarResponse as ServerError<*>
+                throw ServerException(
+                    "Server error : ${localVarError.statusCode} ${localVarError.message.orEmpty()}",
+                    localVarError.statusCode,
+                    localVarResponse
+                )
+            }
+        }
+    }
+
+    /**
+     * @throws IllegalStateException If the request is not correctly configured
+     * @throws IOException Rethrows the OkHttp execute method exception
+     */
+    @Throws(IllegalStateException::class, IOException::class)
+    fun getPetWithHttpInfo(id: String): ApiResponse<Pet?> {
+        val localVariableConfig = getPetRequestConfig(id)
+        return request<Unit, Pet>(localVariableConfig)
+    }
+
+    /**
+     * To obtain the request config of the operation getPet
+     */
+    private fun getPetRequestConfig(id: String): RequestConfig<Unit> {
+        val localVariableQuery: MultiValueMap = mutableMapOf<String, List<String>>()
+        val localVariableHeaders: MutableMap<String, String> = mutableMapOf()
+        return RequestConfig(
+            method = RequestMethod.GET,
+            path = "/pets/${encodeURIComponent(id.toString())}",
+            query = localVariableQuery,
+            headers = localVariableHeaders,
+            requiresAuthentication = false
+        )
+    }
+
+    /**
+     * @throws IllegalStateException If the request is not correctly configured
+     * @throws IOException Rethrows the OkHttp execute method exception
+     * @throws UnsupportedOperationException If the API returns an informational or redirection response
+     * @throws ClientException If the API returns a client error response
+     * @throws ServerException If the API returns a server error response
+     */
+    @Throws(
+        IllegalStateException::class,
+        IOException::class,
+        UnsupportedOperationException::class,
+        ClientException::class,
+        ServerException::class
+    )
+    fun deletePet(id: String): Unit {
+        val localVarResponse = deletePetWithHttpInfo(id)
+
+        return when (localVarResponse.responseType) {
+            ResponseType.Success -> Unit
+            ResponseType.Informational -> throw UnsupportedOperationException("Client does not support Informational responses.")
+            ResponseType.Redirection -> throw UnsupportedOperationException("Client does not support Redirection responses.")
+            ResponseType.ClientError -> {
+                val localVarError = localVarResponse as ClientError<*>
+                throw ClientException(
+                    "Client error : ${localVarError.statusCode} ${localVarError.message.orEmpty()}",
+                    localVarError.statusCode,
+                    localVarResponse
+                )
+            }
+
+            ResponseType.ServerError -> {
+                val localVarError = localVarResponse as ServerError<*>
+                throw ServerException(
+                    "Server error : ${localVarError.statusCode} ${localVarError.message.orEmpty()}",
+                    localVarError.statusCode,
+                    localVarResponse
+                )
+            }
+        }
+    }
+
+    /**
+     * @throws IllegalStateException If the request is not correctly configured
+     * @throws IOException Rethrows the OkHttp execute method exception
+     */
+    @Throws(IllegalStateException::class, IOException::class)
+    fun deletePetWithHttpInfo(id: String): ApiResponse<Unit?> {
+        val localVariableConfig = deletePetRequestConfig(id)
+        return request<Unit, Unit>(localVariableConfig)
+    }
+
+    /**
+     * To obtain the request config of the operation deletePet
+     */
+    private fun deletePetRequestConfig(id: String): RequestConfig<Unit> {
+        val localVariableQuery: MultiValueMap = mutableMapOf<String, List<String>>()
+        val localVariableHeaders: MutableMap<String, String> = mutableMapOf()
+        return RequestConfig(
+            method = RequestMethod.DELETE,
+            path = "/pets/${encodeURIComponent(id.toString())}",
+            query = localVariableQuery,
+            headers = localVariableHeaders,
+            requiresAuthentication = false
+        )
+    }
+
+    /**
+     * @throws IllegalStateException If the request is not correctly configured
+     * @throws IOException Rethrows the OkHttp execute method exception
+     * @throws UnsupportedOperationException If the API returns an informational or redirection response
+     * @throws ClientException If the API returns a client error response
+     * @throws ServerException If the API returns a server error response
+     */
+    @Throws(
+        IllegalStateException::class,
+        IOException::class,
+        UnsupportedOperationException::class,
+        ClientException::class,
+        ServerException::class
+    )
+    fun searchPets(): Pet {
+        val localVarResponse = searchPetsWithHttpInfo()
+
+        return when (localVarResponse.responseType) {
+            ResponseType.Success -> (localVarResponse as Success<*>).data as Pet
+            ResponseType.Informational -> throw UnsupportedOperationException("Client does not support Informational responses.")
+            ResponseType.Redirection -> throw UnsupportedOperationException("Client does not support Redirection responses.")
+            ResponseType.ClientError -> {
+                val localVarError = localVarResponse as ClientError<*>
+                throw ClientException(
+                    "Client error : ${localVarError.statusCode} ${localVarError.message.orEmpty()}",
+                    localVarError.statusCode,
+                    localVarResponse
+                )
+            }
+
+            ResponseType.ServerError -> {
+                val localVarError = localVarResponse as ServerError<*>
+                throw ServerException(
+                    "Server error : ${localVarError.statusCode} ${localVarError.message.orEmpty()}",
+                    localVarError.statusCode,
+                    localVarResponse
+                )
+            }
+        }
+    }
+
+    /**
+     * @throws IllegalStateException If the request is not correctly configured
+     * @throws IOException Rethrows the OkHttp execute method exception
+     */
+    @Throws(IllegalStateException::class, IOException::class)
+    fun searchPetsWithHttpInfo(): ApiResponse<Pet?> {
+        val localVariableConfig = searchPetsRequestConfig()
+        return request<Unit, Pet>(localVariableConfig)
+    }
+
+    /**
+     * To obtain the request config of the operation searchPets
+     */
+    private fun searchPetsRequestConfig(): RequestConfig<Unit> {
+        val localVariableQuery: MultiValueMap = mutableMapOf<String, List<String>>()
+        val localVariableHeaders: MutableMap<String, String> = mutableMapOf()
+        return RequestConfig(
+            method = RequestMethod.GET,
+            path = "/pets/search",
+            query = localVariableQuery,
+            headers = localVariableHeaders,
+            requiresAuthentication = false
+        )
+    }
+
+    private fun encodeURIComponent(uriComponent: String): String = HttpUrl.Builder().scheme("http").host("localhost").addPathSegment(uriComponent).build().encodedPathSegments[0]
+}
+
+└───────────────────────────────────────────────────────┘
+
+┌───────────────────────────────────────────────────────────────────────────────┐
+│ <root>/out/com/openapi/generated/api/client/infrastructure/ApiAbstractions.kt │
+├───────────────────────────────────────────────────────────────────────────────┤
+package com.openapi.generated.api.client.infrastructure
+
+typealias MultiValueMap = MutableMap<String, List<String>>
+
+fun collectionDelimiter(collectionFormat: String) = when (collectionFormat) {
+    "csv" -> ","
+    "tsv" -> "\t"
+    "pipe" -> "|"
+    "space" -> " "
+    else -> ""
+}
+
+val defaultMultiValueConverter: (item: Any?) -> String = { item -> "$item" }
+
+fun <T : Any?> toMultiValue(
+    items: Array<T>,
+    collectionFormat: String,
+    map: (item: T) -> String = defaultMultiValueConverter
+) = toMultiValue(items.asIterable(), collectionFormat, map)
+
+fun <T : Any?> toMultiValue(
+    items: Iterable<T>,
+    collectionFormat: String,
+    map: (item: T) -> String = defaultMultiValueConverter
+): List<String> {
+    return when (collectionFormat) {
+        "multi" -> items.map(map)
+        else -> listOf(items.joinToString(separator = collectionDelimiter(collectionFormat), transform = map))
+    }
+}
+
+└───────────────────────────────────────────────────────────────────────────────┘
+
+┌─────────────────────────────────────────────────────────────────────────┐
+│ <root>/out/com/openapi/generated/api/client/infrastructure/ApiClient.kt │
+├─────────────────────────────────────────────────────────────────────────┤
+package com.openapi.generated.api.client.infrastructure
+
+import com.fasterxml.jackson.core.type.TypeReference
+import com.fasterxml.jackson.databind.ObjectMapper
+import okhttp3.FormBody
+import okhttp3.Headers.Companion.toHeaders
+import okhttp3.HttpUrl.Companion.toHttpUrlOrNull
+import okhttp3.MediaType.Companion.toMediaTypeOrNull
+import okhttp3.MultipartBody
+import okhttp3.Call.Factory
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import okhttp3.RequestBody
+import okhttp3.RequestBody.Companion.asRequestBody
+import okhttp3.RequestBody.Companion.toRequestBody
+import okhttp3.ResponseBody
+import okhttp3.internal.EMPTY_REQUEST
+import java.io.File
+import java.net.URLConnection
+import java.time.LocalDate
+import java.time.LocalDateTime
+import java.time.LocalTime
+import java.time.OffsetDateTime
+import java.time.OffsetTime
+import java.util.Locale
+
+open class ApiClient(val baseUrl: String, val client: Factory = defaultClient, val objectMapper: ObjectMapper = Serializer.jacksonObjectMapper) {
+    companion object {
+        protected const val ContentType = "Content-Type"
+        protected const val Accept = "Accept"
+        protected const val Authorization = "Authorization"
+        protected const val JsonMediaType = "application/json"
+        protected const val FormDataMediaType = "multipart/form-data"
+        protected const val FormUrlEncMediaType = "application/x-www-form-urlencoded"
+        protected const val XmlMediaType = "application/xml"
+
+        val apiKey: MutableMap<String, String> = mutableMapOf()
+        val apiKeyPrefix: MutableMap<String, String> = mutableMapOf()
+        var username: String? = null
+        var password: String? = null
+        var accessToken: String? = null
+        const val baseUrlKey = "org.openapitools.client.baseUrl"
+
+        @JvmStatic
+        val defaultClient: OkHttpClient by lazy {
+            builder.build()
+        }
+
+        @JvmStatic
+        val builder: OkHttpClient.Builder = OkHttpClient.Builder()
+    }
+
+    /**
+     * Guess Content-Type header from the given file (defaults to "application/octet-stream").
+     *
+     * @param file The given file
+     * @return The guessed Content-Type
+     */
+    protected fun guessContentTypeFromFile(file: File): String {
+        val contentType = URLConnection.guessContentTypeFromName(file.name)
+        return contentType ?: "application/octet-stream"
+    }
+
+    protected inline fun <reified T> requestBody(content: T, mediaType: String?): RequestBody =
+        when {
+            content is File -> content.asRequestBody(
+                (mediaType ?: guessContentTypeFromFile(content)).toMediaTypeOrNull()
+            )
+
+            mediaType == FormDataMediaType ->
+                MultipartBody.Builder()
+                    .setType(MultipartBody.FORM)
+                    .apply {
+                        // content's type *must* be Map<String, PartConfig<*>>
+                        @Suppress("UNCHECKED_CAST")
+                        (content as Map<String, PartConfig<*>>).forEach { (name, part) ->
+                            if (part.body is File) {
+                                val partHeaders = part.headers.toMutableMap() +
+                                    ("Content-Disposition" to "form-data; name=\"$name\"; filename=\"${part.body.name}\"")
+                                val fileMediaType = guessContentTypeFromFile(part.body).toMediaTypeOrNull()
+                                addPart(
+                                    partHeaders.toHeaders(),
+                                    part.body.asRequestBody(fileMediaType)
+                                )
+                            } else {
+                                val partHeaders = part.headers.toMutableMap() +
+                                    ("Content-Disposition" to "form-data; name=\"$name\"")
+                                addPart(
+                                    partHeaders.toHeaders(),
+                                    objectMapper.writeValueAsString(part.body)
+                                        .toRequestBody(JsonMediaType.toMediaTypeOrNull())
+                                )
+                            }
+                        }
+                    }.build()
+
+            mediaType == FormUrlEncMediaType -> {
+                FormBody.Builder().apply {
+                    // content's type *must* be Map<String, PartConfig<*>>
+                    @Suppress("UNCHECKED_CAST")
+                    (content as Map<String, PartConfig<*>>).forEach { (name, part) ->
+                        add(name, parameterToString(part.body))
+                    }
+                }.build()
+            }
+
+            mediaType == null || mediaType.startsWith("application/") && mediaType.endsWith("json") ->
+                if (content == null) {
+                    EMPTY_REQUEST
+                } else {
+                    objectMapper.writeValueAsString(content)
+                        .toRequestBody((mediaType ?: JsonMediaType).toMediaTypeOrNull())
+                }
+
+            mediaType == XmlMediaType -> throw UnsupportedOperationException("xml not currently supported.")
+            // TODO: this should be extended with other serializers
+            else -> throw UnsupportedOperationException("requestBody currently only supports JSON body and File body.")
+        }
+
+    protected inline fun <reified T : Any?> responseBody(body: ResponseBody?, mediaType: String? = JsonMediaType): T? {
+        if (body == null) {
+            return null
+        }
+        if (T::class.java == File::class.java) {
+            // return tempFile
+            // Attention: if you are developing an android app that supports API Level 25 and bellow, please check flag supportAndroidApiLevel25AndBelow in https://openapi-generator.tech/docs/generators/kotlin#config-options
+            val tempFile = java.nio.file.Files.createTempFile("tmp.org.openapitools.client", null).toFile()
+            tempFile.deleteOnExit()
+            body.byteStream().use { inputStream ->
+                tempFile.outputStream().use { tempFileOutputStream ->
+                    inputStream.copyTo(tempFileOutputStream)
+                }
+            }
+            return tempFile as T
+        }
+        val bodyContent = body.string()
+        if (bodyContent.isEmpty()) {
+            return null
+        }
+        return when {
+            mediaType == null || (mediaType.startsWith("application/") && mediaType.endsWith("json")) ->
+                objectMapper.readValue(bodyContent, object : TypeReference<T>() {})
+
+            mediaType.startsWith("text/") && T::class.java == String::class.java -> bodyContent as T
+
+            else -> throw UnsupportedOperationException("responseBody currently only supports JSON body.")
+        }
+    }
+
+    protected inline fun <reified I, reified T : Any?> request(requestConfig: RequestConfig<I>): ApiResponse<T?> {
+        val httpUrl = baseUrl.toHttpUrlOrNull() ?: throw IllegalStateException("baseUrl is invalid.")
+
+        val url = httpUrl.newBuilder()
+            .addEncodedPathSegments(requestConfig.path.trimStart('/'))
+            .apply {
+                requestConfig.query.forEach { query ->
+                    query.value.forEach { queryValue ->
+                        addQueryParameter(query.key, queryValue)
+                    }
+                }
+            }.build()
+
+        // take content-type/accept from spec or set to default (application/json) if not defined
+        if (requestConfig.body != null && requestConfig.headers[ContentType].isNullOrEmpty()) {
+            requestConfig.headers[ContentType] = JsonMediaType
+        }
+        if (requestConfig.headers[Accept].isNullOrEmpty()) {
+            requestConfig.headers[Accept] = JsonMediaType
+        }
+        val headers = requestConfig.headers
+
+        if (headers[Accept].isNullOrEmpty()) {
+            throw kotlin.IllegalStateException("Missing Accept header. This is required.")
+        }
+
+        val contentType = if (headers[ContentType] != null) {
+            // TODO: support multiple contentType options here.
+            (headers[ContentType] as String).substringBefore(";").lowercase(Locale.getDefault())
+        } else {
+            null
+        }
+
+        val request = when (requestConfig.method) {
+            RequestMethod.DELETE -> Request.Builder().url(url).delete(requestBody(requestConfig.body, contentType))
+            RequestMethod.GET -> Request.Builder().url(url)
+            RequestMethod.HEAD -> Request.Builder().url(url).head()
+            RequestMethod.PATCH -> Request.Builder().url(url).patch(requestBody(requestConfig.body, contentType))
+            RequestMethod.PUT -> Request.Builder().url(url).put(requestBody(requestConfig.body, contentType))
+            RequestMethod.POST -> Request.Builder().url(url).post(requestBody(requestConfig.body, contentType))
+            RequestMethod.OPTIONS -> Request.Builder().url(url).method("OPTIONS", null)
+        }.apply {
+            headers.forEach { header -> addHeader(header.key, header.value) }
+        }.build()
+
+        val response = client.newCall(request).execute()
+
+        val accept = response.header(ContentType)?.substringBefore(";")?.lowercase(Locale.getDefault())
+
+        // TODO: handle specific mapping types. e.g. Map<int, Class<?>>
+        return when {
+            response.isRedirect -> Redirection(
+                response.code,
+                response.headers.toMultimap()
+            )
+
+            response.isInformational -> Informational(
+                response.message,
+                response.code,
+                response.headers.toMultimap()
+            )
+
+            response.isSuccessful -> Success(
+                responseBody(response.body, accept),
+                response.code,
+                response.headers.toMultimap()
+            )
+
+            response.isClientError -> ClientError(
+                response.message,
+                response.body?.string(),
+                response.code,
+                response.headers.toMultimap()
+            )
+
+            else -> ServerError(
+                response.message,
+                response.body?.string(),
+                response.code,
+                response.headers.toMultimap()
+            )
+        }
+    }
+
+    protected fun parameterToString(value: Any?): String = when (value) {
+        null -> ""
+        is Array<*> -> toMultiValue(value, "csv").toString()
+        is Iterable<*> -> toMultiValue(value, "csv").toString()
+        is OffsetDateTime, is OffsetTime, is LocalDateTime, is LocalDate, is LocalTime ->
+            parseDateToQueryString(value)
+
+        else -> value.toString()
+    }
+
+    protected fun parseDateToQueryString(value: Any): String {
+        /*
+        .replace("\"", "") converts the json object string to an actual string for the query parameter.
+        The moshi or gson adapter allows a more generic solution instead of trying to use a native
+        formatter. It also easily allows to provide a simple way to define a custom date format pattern
+        inside a gson/moshi adapter.
+        */
+        return objectMapper.writeValueAsString(value).replace("\"", "")
+    }
+}
+
+└─────────────────────────────────────────────────────────────────────────┘
+
+┌───────────────────────────────────────────────────────────────────────────┐
+│ <root>/out/com/openapi/generated/api/client/infrastructure/ApiResponse.kt │
+├───────────────────────────────────────────────────────────────────────────┤
+package com.openapi.generated.api.client.infrastructure
+
+enum class ResponseType {
+    Success, Informational, Redirection, ClientError, ServerError
+}
+
+interface Response
+
+abstract class ApiResponse<T>(val responseType: ResponseType) : Response {
+    abstract val statusCode: Int
+    abstract val headers: Map<String, List<String>>
+}
+
+class Success<T>(
+    val data: T,
+    override val statusCode: Int = -1,
+    override val headers: Map<String, List<String>> = mapOf()
+) : ApiResponse<T>(ResponseType.Success)
+
+class Informational<T>(
+    val statusText: String,
+    override val statusCode: Int = -1,
+    override val headers: Map<String, List<String>> = mapOf()
+) : ApiResponse<T>(ResponseType.Informational)
+
+class Redirection<T>(
+    override val statusCode: Int = -1,
+    override val headers: Map<String, List<String>> = mapOf()
+) : ApiResponse<T>(ResponseType.Redirection)
+
+class ClientError<T>(
+    val message: String? = null,
+    val body: Any? = null,
+    override val statusCode: Int = -1,
+    override val headers: Map<String, List<String>> = mapOf()
+) : ApiResponse<T>(ResponseType.ClientError)
+
+class ServerError<T>(
+    val message: String? = null,
+    val body: Any? = null,
+    override val statusCode: Int = -1,
+    override val headers: Map<String, List<String>>
+) : ApiResponse<T>(ResponseType.ServerError)
+
+└───────────────────────────────────────────────────────────────────────────┘
+
+┌──────────────────────────────────────────────────────────────────────┐
+│ <root>/out/com/openapi/generated/api/client/infrastructure/Errors.kt │
+├──────────────────────────────────────────────────────────────────────┤
+@file:Suppress("unused")
+
+package com.openapi.generated.api.client.infrastructure
+
+import java.lang.RuntimeException
+
+open class ClientException(message: kotlin.String? = null, val statusCode: Int = -1, val response: Response? = null) :
+    RuntimeException(message) {
+
+    companion object {
+        private const val serialVersionUID: Long = 123L
+    }
+}
+
+open class ServerException(message: kotlin.String? = null, val statusCode: Int = -1, val response: Response? = null) :
+    RuntimeException(message) {
+
+    companion object {
+        private const val serialVersionUID: Long = 456L
+    }
+}
+
+└──────────────────────────────────────────────────────────────────────┘
+
+┌──────────────────────────────────────────────────────────────────────────┐
+│ <root>/out/com/openapi/generated/api/client/infrastructure/PartConfig.kt │
+├──────────────────────────────────────────────────────────────────────────┤
+package com.openapi.generated.api.client.infrastructure
+
+/**
+ * Defines a config object for a given part of a multi-part request.
+ * NOTE: Headers is a Map<String,String> because rfc2616 defines
+ *       multi-valued headers as csv-only.
+ */
+data class PartConfig<T>(
+    val headers: MutableMap<String, String> = mutableMapOf(),
+    val body: T? = null
+)
+
+└──────────────────────────────────────────────────────────────────────────┘
+
+┌─────────────────────────────────────────────────────────────────────────────┐
+│ <root>/out/com/openapi/generated/api/client/infrastructure/RequestConfig.kt │
+├─────────────────────────────────────────────────────────────────────────────┤
+package com.openapi.generated.api.client.infrastructure
+
+/**
+ * Defines a config object for a given request.
+ * NOTE: This object doesn't include 'body' because it
+ *       allows for caching of the constructed object
+ *       for many request definitions.
+ * NOTE: Headers is a Map<String,String> because rfc2616 defines
+ *       multi-valued headers as csv-only.
+ */
+data class RequestConfig<T>(
+    val method: RequestMethod,
+    val path: String,
+    val headers: MutableMap<String, String> = mutableMapOf(),
+    val query: MutableMap<String, List<String>> = mutableMapOf(),
+    val requiresAuthentication: Boolean,
+    val body: T? = null
+)
+
+└─────────────────────────────────────────────────────────────────────────────┘
+
+┌─────────────────────────────────────────────────────────────────────────────┐
+│ <root>/out/com/openapi/generated/api/client/infrastructure/RequestMethod.kt │
+├─────────────────────────────────────────────────────────────────────────────┤
+package com.openapi.generated.api.client.infrastructure
+
+/**
+ * Provides enumerated HTTP verbs
+ */
+enum class RequestMethod {
+    GET, DELETE, HEAD, OPTIONS, PATCH, POST, PUT
+}
+
+└─────────────────────────────────────────────────────────────────────────────┘
+
+┌──────────────────────────────────────────────────────────────────────────────────┐
+│ <root>/out/com/openapi/generated/api/client/infrastructure/ResponseExtensions.kt │
+├──────────────────────────────────────────────────────────────────────────────────┤
+package com.openapi.generated.api.client.infrastructure
+
+import okhttp3.Response
+
+/**
+ * Provides an extension to evaluation whether the response is a 1xx code
+ */
+val Response.isInformational: Boolean get() = this.code in 100..199
+
+/**
+ * Provides an extension to evaluation whether the response is a 3xx code
+ */
+@Suppress("EXTENSION_SHADOWED_BY_MEMBER")
+val Response.isRedirect: Boolean get() = this.code in 300..399
+
+/**
+ * Provides an extension to evaluation whether the response is a 4xx code
+ */
+val Response.isClientError: Boolean get() = this.code in 400..499
+
+/**
+ * Provides an extension to evaluation whether the response is a 5xx (Standard) through 999 (non-standard) code
+ */
+val Response.isServerError: Boolean get() = this.code in 500..999
+
+└──────────────────────────────────────────────────────────────────────────────────┘
+
+┌──────────────────────────────────────────────────────────────────────────┐
+│ <root>/out/com/openapi/generated/api/client/infrastructure/Serializer.kt │
+├──────────────────────────────────────────────────────────────────────────┤
+package com.openapi.generated.api.client.infrastructure
+
+import com.fasterxml.jackson.annotation.JsonInclude
+import com.fasterxml.jackson.databind.DeserializationFeature
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.databind.SerializationFeature
+import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+
+object Serializer {
+    val jacksonObjectMapper: ObjectMapper = run {
+        jacksonObjectMapper()
+            .findAndRegisterModules()
+            .setSerializationInclusion(JsonInclude.Include.NON_ABSENT)
+            .configure(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS, false)
+            .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
+    }
+}
+
+└──────────────────────────────────────────────────────────────────────────┘

--- a/packages/kotlin/tests/.verify/openapi-services/okhttp-3-clients-spring-boot-3.expect.txt
+++ b/packages/kotlin/tests/.verify/openapi-services/okhttp-3-clients-spring-boot-3.expect.txt
@@ -678,7 +678,6 @@ import okhttp3.RequestBody
 import okhttp3.RequestBody.Companion.asRequestBody
 import okhttp3.RequestBody.Companion.toRequestBody
 import okhttp3.ResponseBody
-import okhttp3.internal.EMPTY_REQUEST
 import java.io.File
 import java.net.URLConnection
 import java.time.LocalDate
@@ -770,7 +769,7 @@ open class ApiClient(val baseUrl: String, val client: Factory = defaultClient, v
 
             mediaType == null || mediaType.startsWith("application/") && mediaType.endsWith("json") ->
                 if (content == null) {
-                    EMPTY_REQUEST
+                    ByteArray(0).toRequestBody(null)
                 } else {
                     objectMapper.writeValueAsString(content)
                         .toRequestBody((mediaType ?: JsonMediaType).toMediaTypeOrNull())

--- a/packages/kotlin/tests/.verify/openapi-services/okhttp-3-clients-spring-boot-4.expect.txt
+++ b/packages/kotlin/tests/.verify/openapi-services/okhttp-3-clients-spring-boot-4.expect.txt
@@ -1,0 +1,1104 @@
+┌──────────────────────────────────────┐
+│ state                                │
+├──────────────────────────────────────┤
+{
+  kotlin: {
+    clients: {
+      'service-1': {
+        __source__: 'tag:Pets',
+        packageName: 'com.openapi.generated.api.client',
+        typeName: 'PetsApiClient'
+      }
+    },
+    models: {
+      'schema-1': {
+        __source__: '<root>/test/openapi-files/v3/service-endpoints.yml#/paths//pets/get/responses/200/content/application/json/schema',
+        type: KtReference {
+          classReference: false,
+          generics: [
+            KtReference {
+              classReference: false,
+              generics: [],
+              inject: {},
+              name: 'Pet',
+              nullable: false,
+              packageName: 'com.openapi.generated.model',
+              subReference: null
+            }
+          ],
+          inject: {},
+          name: 'List',
+          nullable: false,
+          packageName: 'kotlin.collections',
+          subReference: null
+        }
+      },
+      'schema-10': {
+        __source__: '<root>/test/openapi-files/v3/service-endpoints.yml#/components/schemas/Pet',
+        type: KtReference {
+          classReference: false,
+          generics: [],
+          inject: {},
+          name: 'Pet',
+          nullable: false,
+          packageName: 'com.openapi.generated.model',
+          subReference: null
+        }
+      },
+      'schema-11': {
+        __source__: '<root>/test/openapi-files/v3/service-endpoints.yml#/paths//pets/{id}/delete/parameters/0/schema',
+        type: KtReference {
+          classReference: false,
+          generics: [],
+          inject: {},
+          name: 'String',
+          nullable: false,
+          packageName: 'kotlin',
+          subReference: null
+        }
+      },
+      'schema-12': {
+        __source__: '<root>/test/openapi-files/v3/service-endpoints.yml#/components/schemas/Pet',
+        type: KtReference {
+          classReference: false,
+          generics: [],
+          inject: {},
+          name: 'Pet',
+          nullable: false,
+          packageName: 'com.openapi.generated.model',
+          subReference: null
+        }
+      },
+      'schema-13': {
+        __source__: '<root>/test/openapi-files/v3/service-endpoints.yml#/components/schemas/Owner',
+        type: KtReference {
+          classReference: false,
+          generics: [],
+          inject: {},
+          name: 'Owner',
+          nullable: false,
+          packageName: 'com.openapi.generated.model',
+          subReference: null
+        }
+      },
+      'schema-14': {
+        __source__: '<root>/test/openapi-files/v3/service-endpoints.yml#/components/schemas/Owner',
+        type: KtReference {
+          classReference: false,
+          generics: [],
+          inject: {},
+          name: 'Owner',
+          nullable: false,
+          packageName: 'com.openapi.generated.model',
+          subReference: null
+        }
+      },
+      'schema-15': {
+        __source__: '<root>/test/openapi-files/v3/service-endpoints.yml#/components/schemas/Owner/properties/name',
+        type: KtReference {
+          classReference: false,
+          generics: [],
+          inject: {},
+          name: 'String',
+          nullable: false,
+          packageName: 'kotlin',
+          subReference: null
+        }
+      },
+      'schema-2': {
+        __source__: '<root>/test/openapi-files/v3/service-endpoints.yml#/components/schemas/Pet',
+        type: KtReference {
+          classReference: false,
+          generics: [],
+          inject: {},
+          name: 'Pet',
+          nullable: false,
+          packageName: 'com.openapi.generated.model',
+          subReference: null
+        }
+      },
+      'schema-3': {
+        __source__: '<root>/test/openapi-files/v3/service-endpoints.yml#/components/schemas/Pet',
+        type: KtReference {
+          classReference: false,
+          generics: [],
+          inject: {},
+          name: 'Pet',
+          nullable: false,
+          packageName: 'com.openapi.generated.model',
+          subReference: null
+        }
+      },
+      'schema-4': {
+        __source__: '<root>/test/openapi-files/v3/service-endpoints.yml#/components/schemas/Pet/properties/id',
+        type: KtReference {
+          classReference: false,
+          generics: [],
+          inject: {},
+          name: 'String',
+          nullable: false,
+          packageName: 'kotlin',
+          subReference: null
+        }
+      },
+      'schema-5': {
+        __source__: '<root>/test/openapi-files/v3/service-endpoints.yml#/components/schemas/Pet/properties/name',
+        type: KtReference {
+          classReference: false,
+          generics: [],
+          inject: {},
+          name: 'String',
+          nullable: false,
+          packageName: 'kotlin',
+          subReference: null
+        }
+      },
+      'schema-6': {
+        __source__: '<root>/test/openapi-files/v3/service-endpoints.yml#/components/schemas/Pet/properties/tag',
+        type: KtReference {
+          classReference: false,
+          generics: [],
+          inject: {},
+          name: 'String',
+          nullable: false,
+          packageName: 'kotlin',
+          subReference: null
+        }
+      },
+      'schema-7': {
+        __source__: '<root>/test/openapi-files/v3/service-endpoints.yml#/components/schemas/Pet',
+        type: KtReference {
+          classReference: false,
+          generics: [],
+          inject: {},
+          name: 'Pet',
+          nullable: false,
+          packageName: 'com.openapi.generated.model',
+          subReference: null
+        }
+      },
+      'schema-8': {
+        __source__: '<root>/test/openapi-files/v3/service-endpoints.yml#/components/schemas/Pet',
+        type: KtReference {
+          classReference: false,
+          generics: [],
+          inject: {},
+          name: 'Pet',
+          nullable: false,
+          packageName: 'com.openapi.generated.model',
+          subReference: null
+        }
+      },
+      'schema-9': {
+        __source__: '<root>/test/openapi-files/v3/service-endpoints.yml#/paths//pets/{id}/get/parameters/0/schema',
+        type: KtReference {
+          classReference: false,
+          generics: [],
+          inject: {},
+          name: 'String',
+          nullable: false,
+          packageName: 'kotlin',
+          subReference: null
+        }
+      }
+    }
+  }
+}
+└──────────────────────────────────────┘
+
+┌────────────────────────────────────────┐
+│ out/com/openapi/generated/model/Pet.kt │
+├────────────────────────────────────────┤
+package com.openapi.generated.model
+
+import com.fasterxml.jackson.annotation.JsonProperty
+import io.swagger.v3.oas.annotations.media.Schema
+
+data class Pet(
+    @Schema(required = true)
+    @param:JsonProperty("id", required = true)
+    @get:JsonProperty("id", required = true)
+    val id: String,
+
+    @Schema(required = true)
+    @param:JsonProperty("name", required = true)
+    @get:JsonProperty("name", required = true)
+    val name: String,
+
+    @Schema
+    @param:JsonProperty("tag")
+    @get:JsonProperty("tag")
+    val tag: String? = null
+)
+
+└────────────────────────────────────────┘
+
+┌──────────────────────────────────────────┐
+│ out/com/openapi/generated/model/Owner.kt │
+├──────────────────────────────────────────┤
+package com.openapi.generated.model
+
+import com.fasterxml.jackson.annotation.JsonProperty
+import io.swagger.v3.oas.annotations.media.Schema
+
+data class Owner(
+    @Schema(required = true)
+    @param:JsonProperty("name", required = true)
+    @get:JsonProperty("name", required = true)
+    val name: String
+)
+
+└──────────────────────────────────────────┘
+
+┌───────────────────────────────────────────────────────┐
+│ out/com/openapi/generated/api/client/PetsApiClient.kt │
+├───────────────────────────────────────────────────────┤
+package com.openapi.generated.api.client
+
+import com.openapi.generated.api.client.infrastructure.ApiClient
+import com.openapi.generated.api.client.infrastructure.ApiResponse
+import com.openapi.generated.api.client.infrastructure.ClientError
+import com.openapi.generated.api.client.infrastructure.ClientException
+import com.openapi.generated.api.client.infrastructure.MultiValueMap
+import com.openapi.generated.api.client.infrastructure.RequestConfig
+import com.openapi.generated.api.client.infrastructure.RequestMethod
+import com.openapi.generated.api.client.infrastructure.ResponseType
+import com.openapi.generated.api.client.infrastructure.Serializer
+import com.openapi.generated.api.client.infrastructure.ServerError
+import com.openapi.generated.api.client.infrastructure.ServerException
+import com.openapi.generated.api.client.infrastructure.Success
+import com.openapi.generated.model.Pet
+import okhttp3.Call.Factory
+import okhttp3.HttpUrl
+import tools.jackson.databind.ObjectMapper
+import java.io.IOException
+
+class PetsApiClient(
+    basePath: String = defaultBasePath,
+    client: Factory = defaultClient,
+    objectMapper: ObjectMapper = Serializer.jacksonObjectMapper
+) : ApiClient(basePath, objectMapper, client) {
+    companion object {
+        @JvmStatic
+        val defaultBasePath: String by lazy {
+            System.getProperties().getProperty(ApiClient.baseUrlKey, "/")
+        }
+    }
+
+    /**
+     * @throws IllegalStateException If the request is not correctly configured
+     * @throws IOException Rethrows the OkHttp execute method exception
+     * @throws UnsupportedOperationException If the API returns an informational or redirection response
+     * @throws ClientException If the API returns a client error response
+     * @throws ServerException If the API returns a server error response
+     */
+    @Throws(
+        IllegalStateException::class,
+        IOException::class,
+        UnsupportedOperationException::class,
+        ClientException::class,
+        ServerException::class
+    )
+    fun listPets(): List<Pet> {
+        val localVarResponse = listPetsWithHttpInfo()
+
+        return when (localVarResponse.responseType) {
+            ResponseType.Success -> (localVarResponse as Success<*>).data as List<Pet>
+            ResponseType.Informational -> throw UnsupportedOperationException("Client does not support Informational responses.")
+            ResponseType.Redirection -> throw UnsupportedOperationException("Client does not support Redirection responses.")
+            ResponseType.ClientError -> {
+                val localVarError = localVarResponse as ClientError<*>
+                throw ClientException(
+                    "Client error : ${localVarError.statusCode} ${localVarError.message.orEmpty()}",
+                    localVarError.statusCode,
+                    localVarResponse
+                )
+            }
+
+            ResponseType.ServerError -> {
+                val localVarError = localVarResponse as ServerError<*>
+                throw ServerException(
+                    "Server error : ${localVarError.statusCode} ${localVarError.message.orEmpty()}",
+                    localVarError.statusCode,
+                    localVarResponse
+                )
+            }
+        }
+    }
+
+    /**
+     * @throws IllegalStateException If the request is not correctly configured
+     * @throws IOException Rethrows the OkHttp execute method exception
+     */
+    @Throws(IllegalStateException::class, IOException::class)
+    fun listPetsWithHttpInfo(): ApiResponse<List<Pet>?> {
+        val localVariableConfig = listPetsRequestConfig()
+        return request<Unit, List<Pet>>(localVariableConfig)
+    }
+
+    /**
+     * To obtain the request config of the operation listPets
+     */
+    private fun listPetsRequestConfig(): RequestConfig<Unit> {
+        val localVariableQuery: MultiValueMap = mutableMapOf<String, List<String>>()
+        val localVariableHeaders: MutableMap<String, String> = mutableMapOf()
+        return RequestConfig(
+            method = RequestMethod.GET,
+            path = "/pets",
+            query = localVariableQuery,
+            headers = localVariableHeaders,
+            requiresAuthentication = false
+        )
+    }
+
+    /**
+     * @throws IllegalStateException If the request is not correctly configured
+     * @throws IOException Rethrows the OkHttp execute method exception
+     * @throws UnsupportedOperationException If the API returns an informational or redirection response
+     * @throws ClientException If the API returns a client error response
+     * @throws ServerException If the API returns a server error response
+     */
+    @Throws(
+        IllegalStateException::class,
+        IOException::class,
+        UnsupportedOperationException::class,
+        ClientException::class,
+        ServerException::class
+    )
+    fun createPet(pet: Pet): Pet {
+        val localVarResponse = createPetWithHttpInfo(pet)
+
+        return when (localVarResponse.responseType) {
+            ResponseType.Success -> (localVarResponse as Success<*>).data as Pet
+            ResponseType.Informational -> throw UnsupportedOperationException("Client does not support Informational responses.")
+            ResponseType.Redirection -> throw UnsupportedOperationException("Client does not support Redirection responses.")
+            ResponseType.ClientError -> {
+                val localVarError = localVarResponse as ClientError<*>
+                throw ClientException(
+                    "Client error : ${localVarError.statusCode} ${localVarError.message.orEmpty()}",
+                    localVarError.statusCode,
+                    localVarResponse
+                )
+            }
+
+            ResponseType.ServerError -> {
+                val localVarError = localVarResponse as ServerError<*>
+                throw ServerException(
+                    "Server error : ${localVarError.statusCode} ${localVarError.message.orEmpty()}",
+                    localVarError.statusCode,
+                    localVarResponse
+                )
+            }
+        }
+    }
+
+    /**
+     * @throws IllegalStateException If the request is not correctly configured
+     * @throws IOException Rethrows the OkHttp execute method exception
+     */
+    @Throws(IllegalStateException::class, IOException::class)
+    fun createPetWithHttpInfo(pet: Pet): ApiResponse<Pet?> {
+        val localVariableConfig = createPetRequestConfig(pet)
+        return request<Pet, Pet>(localVariableConfig)
+    }
+
+    /**
+     * To obtain the request config of the operation createPet
+     */
+    private fun createPetRequestConfig(pet: Pet): RequestConfig<Pet> {
+        val localVariableBody = pet
+        val localVariableQuery: MultiValueMap = mutableMapOf<String, List<String>>()
+        val localVariableHeaders: MutableMap<String, String> = mutableMapOf()
+        localVariableHeaders["Content-Type"] = "application/json"
+        return RequestConfig(
+            method = RequestMethod.POST,
+            path = "/pets",
+            query = localVariableQuery,
+            headers = localVariableHeaders,
+            requiresAuthentication = false,
+            body = localVariableBody
+        )
+    }
+
+    /**
+     * @throws IllegalStateException If the request is not correctly configured
+     * @throws IOException Rethrows the OkHttp execute method exception
+     * @throws UnsupportedOperationException If the API returns an informational or redirection response
+     * @throws ClientException If the API returns a client error response
+     * @throws ServerException If the API returns a server error response
+     */
+    @Throws(
+        IllegalStateException::class,
+        IOException::class,
+        UnsupportedOperationException::class,
+        ClientException::class,
+        ServerException::class
+    )
+    fun getPet(id: String): Pet {
+        val localVarResponse = getPetWithHttpInfo(id)
+
+        return when (localVarResponse.responseType) {
+            ResponseType.Success -> (localVarResponse as Success<*>).data as Pet
+            ResponseType.Informational -> throw UnsupportedOperationException("Client does not support Informational responses.")
+            ResponseType.Redirection -> throw UnsupportedOperationException("Client does not support Redirection responses.")
+            ResponseType.ClientError -> {
+                val localVarError = localVarResponse as ClientError<*>
+                throw ClientException(
+                    "Client error : ${localVarError.statusCode} ${localVarError.message.orEmpty()}",
+                    localVarError.statusCode,
+                    localVarResponse
+                )
+            }
+
+            ResponseType.ServerError -> {
+                val localVarError = localVarResponse as ServerError<*>
+                throw ServerException(
+                    "Server error : ${localVarError.statusCode} ${localVarError.message.orEmpty()}",
+                    localVarError.statusCode,
+                    localVarResponse
+                )
+            }
+        }
+    }
+
+    /**
+     * @throws IllegalStateException If the request is not correctly configured
+     * @throws IOException Rethrows the OkHttp execute method exception
+     */
+    @Throws(IllegalStateException::class, IOException::class)
+    fun getPetWithHttpInfo(id: String): ApiResponse<Pet?> {
+        val localVariableConfig = getPetRequestConfig(id)
+        return request<Unit, Pet>(localVariableConfig)
+    }
+
+    /**
+     * To obtain the request config of the operation getPet
+     */
+    private fun getPetRequestConfig(id: String): RequestConfig<Unit> {
+        val localVariableQuery: MultiValueMap = mutableMapOf<String, List<String>>()
+        val localVariableHeaders: MutableMap<String, String> = mutableMapOf()
+        return RequestConfig(
+            method = RequestMethod.GET,
+            path = "/pets/${encodeURIComponent(id.toString())}",
+            query = localVariableQuery,
+            headers = localVariableHeaders,
+            requiresAuthentication = false
+        )
+    }
+
+    /**
+     * @throws IllegalStateException If the request is not correctly configured
+     * @throws IOException Rethrows the OkHttp execute method exception
+     * @throws UnsupportedOperationException If the API returns an informational or redirection response
+     * @throws ClientException If the API returns a client error response
+     * @throws ServerException If the API returns a server error response
+     */
+    @Throws(
+        IllegalStateException::class,
+        IOException::class,
+        UnsupportedOperationException::class,
+        ClientException::class,
+        ServerException::class
+    )
+    fun deletePet(id: String): Unit {
+        val localVarResponse = deletePetWithHttpInfo(id)
+
+        return when (localVarResponse.responseType) {
+            ResponseType.Success -> Unit
+            ResponseType.Informational -> throw UnsupportedOperationException("Client does not support Informational responses.")
+            ResponseType.Redirection -> throw UnsupportedOperationException("Client does not support Redirection responses.")
+            ResponseType.ClientError -> {
+                val localVarError = localVarResponse as ClientError<*>
+                throw ClientException(
+                    "Client error : ${localVarError.statusCode} ${localVarError.message.orEmpty()}",
+                    localVarError.statusCode,
+                    localVarResponse
+                )
+            }
+
+            ResponseType.ServerError -> {
+                val localVarError = localVarResponse as ServerError<*>
+                throw ServerException(
+                    "Server error : ${localVarError.statusCode} ${localVarError.message.orEmpty()}",
+                    localVarError.statusCode,
+                    localVarResponse
+                )
+            }
+        }
+    }
+
+    /**
+     * @throws IllegalStateException If the request is not correctly configured
+     * @throws IOException Rethrows the OkHttp execute method exception
+     */
+    @Throws(IllegalStateException::class, IOException::class)
+    fun deletePetWithHttpInfo(id: String): ApiResponse<Unit?> {
+        val localVariableConfig = deletePetRequestConfig(id)
+        return request<Unit, Unit>(localVariableConfig)
+    }
+
+    /**
+     * To obtain the request config of the operation deletePet
+     */
+    private fun deletePetRequestConfig(id: String): RequestConfig<Unit> {
+        val localVariableQuery: MultiValueMap = mutableMapOf<String, List<String>>()
+        val localVariableHeaders: MutableMap<String, String> = mutableMapOf()
+        return RequestConfig(
+            method = RequestMethod.DELETE,
+            path = "/pets/${encodeURIComponent(id.toString())}",
+            query = localVariableQuery,
+            headers = localVariableHeaders,
+            requiresAuthentication = false
+        )
+    }
+
+    /**
+     * @throws IllegalStateException If the request is not correctly configured
+     * @throws IOException Rethrows the OkHttp execute method exception
+     * @throws UnsupportedOperationException If the API returns an informational or redirection response
+     * @throws ClientException If the API returns a client error response
+     * @throws ServerException If the API returns a server error response
+     */
+    @Throws(
+        IllegalStateException::class,
+        IOException::class,
+        UnsupportedOperationException::class,
+        ClientException::class,
+        ServerException::class
+    )
+    fun searchPets(): Pet {
+        val localVarResponse = searchPetsWithHttpInfo()
+
+        return when (localVarResponse.responseType) {
+            ResponseType.Success -> (localVarResponse as Success<*>).data as Pet
+            ResponseType.Informational -> throw UnsupportedOperationException("Client does not support Informational responses.")
+            ResponseType.Redirection -> throw UnsupportedOperationException("Client does not support Redirection responses.")
+            ResponseType.ClientError -> {
+                val localVarError = localVarResponse as ClientError<*>
+                throw ClientException(
+                    "Client error : ${localVarError.statusCode} ${localVarError.message.orEmpty()}",
+                    localVarError.statusCode,
+                    localVarResponse
+                )
+            }
+
+            ResponseType.ServerError -> {
+                val localVarError = localVarResponse as ServerError<*>
+                throw ServerException(
+                    "Server error : ${localVarError.statusCode} ${localVarError.message.orEmpty()}",
+                    localVarError.statusCode,
+                    localVarResponse
+                )
+            }
+        }
+    }
+
+    /**
+     * @throws IllegalStateException If the request is not correctly configured
+     * @throws IOException Rethrows the OkHttp execute method exception
+     */
+    @Throws(IllegalStateException::class, IOException::class)
+    fun searchPetsWithHttpInfo(): ApiResponse<Pet?> {
+        val localVariableConfig = searchPetsRequestConfig()
+        return request<Unit, Pet>(localVariableConfig)
+    }
+
+    /**
+     * To obtain the request config of the operation searchPets
+     */
+    private fun searchPetsRequestConfig(): RequestConfig<Unit> {
+        val localVariableQuery: MultiValueMap = mutableMapOf<String, List<String>>()
+        val localVariableHeaders: MutableMap<String, String> = mutableMapOf()
+        return RequestConfig(
+            method = RequestMethod.GET,
+            path = "/pets/search",
+            query = localVariableQuery,
+            headers = localVariableHeaders,
+            requiresAuthentication = false
+        )
+    }
+
+    private fun encodeURIComponent(uriComponent: String): String = HttpUrl.Builder().scheme("http").host("localhost").addPathSegment(uriComponent).build().encodedPathSegments[0]
+}
+
+└───────────────────────────────────────────────────────┘
+
+┌───────────────────────────────────────────────────────────────────────────────┐
+│ <root>/out/com/openapi/generated/api/client/infrastructure/ApiAbstractions.kt │
+├───────────────────────────────────────────────────────────────────────────────┤
+package com.openapi.generated.api.client.infrastructure
+
+typealias MultiValueMap = MutableMap<String, List<String>>
+
+fun collectionDelimiter(collectionFormat: String) = when (collectionFormat) {
+    "csv" -> ","
+    "tsv" -> "\t"
+    "pipe" -> "|"
+    "space" -> " "
+    else -> ""
+}
+
+val defaultMultiValueConverter: (item: Any?) -> String = { item -> "$item" }
+
+fun <T : Any?> toMultiValue(
+    items: Array<T>,
+    collectionFormat: String,
+    map: (item: T) -> String = defaultMultiValueConverter
+) = toMultiValue(items.asIterable(), collectionFormat, map)
+
+fun <T : Any?> toMultiValue(
+    items: Iterable<T>,
+    collectionFormat: String,
+    map: (item: T) -> String = defaultMultiValueConverter
+): List<String> {
+    return when (collectionFormat) {
+        "multi" -> items.map(map)
+        else -> listOf(items.joinToString(separator = collectionDelimiter(collectionFormat), transform = map))
+    }
+}
+
+└───────────────────────────────────────────────────────────────────────────────┘
+
+┌─────────────────────────────────────────────────────────────────────────┐
+│ <root>/out/com/openapi/generated/api/client/infrastructure/ApiClient.kt │
+├─────────────────────────────────────────────────────────────────────────┤
+package com.openapi.generated.api.client.infrastructure
+
+import tools.jackson.core.type.TypeReference
+import tools.jackson.databind.ObjectMapper
+import okhttp3.FormBody
+import okhttp3.Headers.Companion.toHeaders
+import okhttp3.HttpUrl.Companion.toHttpUrlOrNull
+import okhttp3.MediaType.Companion.toMediaTypeOrNull
+import okhttp3.MultipartBody
+import okhttp3.Call.Factory
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import okhttp3.RequestBody
+import okhttp3.RequestBody.Companion.asRequestBody
+import okhttp3.RequestBody.Companion.toRequestBody
+import okhttp3.ResponseBody
+import okhttp3.internal.EMPTY_REQUEST
+import java.io.File
+import java.net.URLConnection
+import java.time.LocalDate
+import java.time.LocalDateTime
+import java.time.LocalTime
+import java.time.OffsetDateTime
+import java.time.OffsetTime
+import java.util.Locale
+
+open class ApiClient(val baseUrl: String, val client: Factory = defaultClient, val objectMapper: ObjectMapper = Serializer.jacksonObjectMapper) {
+    companion object {
+        protected const val ContentType = "Content-Type"
+        protected const val Accept = "Accept"
+        protected const val Authorization = "Authorization"
+        protected const val JsonMediaType = "application/json"
+        protected const val FormDataMediaType = "multipart/form-data"
+        protected const val FormUrlEncMediaType = "application/x-www-form-urlencoded"
+        protected const val XmlMediaType = "application/xml"
+
+        val apiKey: MutableMap<String, String> = mutableMapOf()
+        val apiKeyPrefix: MutableMap<String, String> = mutableMapOf()
+        var username: String? = null
+        var password: String? = null
+        var accessToken: String? = null
+        const val baseUrlKey = "org.openapitools.client.baseUrl"
+
+        @JvmStatic
+        val defaultClient: OkHttpClient by lazy {
+            builder.build()
+        }
+
+        @JvmStatic
+        val builder: OkHttpClient.Builder = OkHttpClient.Builder()
+    }
+
+    /**
+     * Guess Content-Type header from the given file (defaults to "application/octet-stream").
+     *
+     * @param file The given file
+     * @return The guessed Content-Type
+     */
+    protected fun guessContentTypeFromFile(file: File): String {
+        val contentType = URLConnection.guessContentTypeFromName(file.name)
+        return contentType ?: "application/octet-stream"
+    }
+
+    protected inline fun <reified T> requestBody(content: T, mediaType: String?): RequestBody =
+        when {
+            content is File -> content.asRequestBody(
+                (mediaType ?: guessContentTypeFromFile(content)).toMediaTypeOrNull()
+            )
+
+            mediaType == FormDataMediaType ->
+                MultipartBody.Builder()
+                    .setType(MultipartBody.FORM)
+                    .apply {
+                        // content's type *must* be Map<String, PartConfig<*>>
+                        @Suppress("UNCHECKED_CAST")
+                        (content as Map<String, PartConfig<*>>).forEach { (name, part) ->
+                            if (part.body is File) {
+                                val partHeaders = part.headers.toMutableMap() +
+                                    ("Content-Disposition" to "form-data; name=\"$name\"; filename=\"${part.body.name}\"")
+                                val fileMediaType = guessContentTypeFromFile(part.body).toMediaTypeOrNull()
+                                addPart(
+                                    partHeaders.toHeaders(),
+                                    part.body.asRequestBody(fileMediaType)
+                                )
+                            } else {
+                                val partHeaders = part.headers.toMutableMap() +
+                                    ("Content-Disposition" to "form-data; name=\"$name\"")
+                                addPart(
+                                    partHeaders.toHeaders(),
+                                    objectMapper.writeValueAsString(part.body)
+                                        .toRequestBody(JsonMediaType.toMediaTypeOrNull())
+                                )
+                            }
+                        }
+                    }.build()
+
+            mediaType == FormUrlEncMediaType -> {
+                FormBody.Builder().apply {
+                    // content's type *must* be Map<String, PartConfig<*>>
+                    @Suppress("UNCHECKED_CAST")
+                    (content as Map<String, PartConfig<*>>).forEach { (name, part) ->
+                        add(name, parameterToString(part.body))
+                    }
+                }.build()
+            }
+
+            mediaType == null || mediaType.startsWith("application/") && mediaType.endsWith("json") ->
+                if (content == null) {
+                    EMPTY_REQUEST
+                } else {
+                    objectMapper.writeValueAsString(content)
+                        .toRequestBody((mediaType ?: JsonMediaType).toMediaTypeOrNull())
+                }
+
+            mediaType == XmlMediaType -> throw UnsupportedOperationException("xml not currently supported.")
+            // TODO: this should be extended with other serializers
+            else -> throw UnsupportedOperationException("requestBody currently only supports JSON body and File body.")
+        }
+
+    protected inline fun <reified T : Any?> responseBody(body: ResponseBody?, mediaType: String? = JsonMediaType): T? {
+        if (body == null) {
+            return null
+        }
+        if (T::class.java == File::class.java) {
+            // return tempFile
+            // Attention: if you are developing an android app that supports API Level 25 and bellow, please check flag supportAndroidApiLevel25AndBelow in https://openapi-generator.tech/docs/generators/kotlin#config-options
+            val tempFile = java.nio.file.Files.createTempFile("tmp.org.openapitools.client", null).toFile()
+            tempFile.deleteOnExit()
+            body.byteStream().use { inputStream ->
+                tempFile.outputStream().use { tempFileOutputStream ->
+                    inputStream.copyTo(tempFileOutputStream)
+                }
+            }
+            return tempFile as T
+        }
+        val bodyContent = body.string()
+        if (bodyContent.isEmpty()) {
+            return null
+        }
+        return when {
+            mediaType == null || (mediaType.startsWith("application/") && mediaType.endsWith("json")) ->
+                objectMapper.readValue(bodyContent, object : TypeReference<T>() {})
+
+            mediaType.startsWith("text/") && T::class.java == String::class.java -> bodyContent as T
+
+            else -> throw UnsupportedOperationException("responseBody currently only supports JSON body.")
+        }
+    }
+
+    protected inline fun <reified I, reified T : Any?> request(requestConfig: RequestConfig<I>): ApiResponse<T?> {
+        val httpUrl = baseUrl.toHttpUrlOrNull() ?: throw IllegalStateException("baseUrl is invalid.")
+
+        val url = httpUrl.newBuilder()
+            .addEncodedPathSegments(requestConfig.path.trimStart('/'))
+            .apply {
+                requestConfig.query.forEach { query ->
+                    query.value.forEach { queryValue ->
+                        addQueryParameter(query.key, queryValue)
+                    }
+                }
+            }.build()
+
+        // take content-type/accept from spec or set to default (application/json) if not defined
+        if (requestConfig.body != null && requestConfig.headers[ContentType].isNullOrEmpty()) {
+            requestConfig.headers[ContentType] = JsonMediaType
+        }
+        if (requestConfig.headers[Accept].isNullOrEmpty()) {
+            requestConfig.headers[Accept] = JsonMediaType
+        }
+        val headers = requestConfig.headers
+
+        if (headers[Accept].isNullOrEmpty()) {
+            throw kotlin.IllegalStateException("Missing Accept header. This is required.")
+        }
+
+        val contentType = if (headers[ContentType] != null) {
+            // TODO: support multiple contentType options here.
+            (headers[ContentType] as String).substringBefore(";").lowercase(Locale.getDefault())
+        } else {
+            null
+        }
+
+        val request = when (requestConfig.method) {
+            RequestMethod.DELETE -> Request.Builder().url(url).delete(requestBody(requestConfig.body, contentType))
+            RequestMethod.GET -> Request.Builder().url(url)
+            RequestMethod.HEAD -> Request.Builder().url(url).head()
+            RequestMethod.PATCH -> Request.Builder().url(url).patch(requestBody(requestConfig.body, contentType))
+            RequestMethod.PUT -> Request.Builder().url(url).put(requestBody(requestConfig.body, contentType))
+            RequestMethod.POST -> Request.Builder().url(url).post(requestBody(requestConfig.body, contentType))
+            RequestMethod.OPTIONS -> Request.Builder().url(url).method("OPTIONS", null)
+        }.apply {
+            headers.forEach { header -> addHeader(header.key, header.value) }
+        }.build()
+
+        val response = client.newCall(request).execute()
+
+        val accept = response.header(ContentType)?.substringBefore(";")?.lowercase(Locale.getDefault())
+
+        // TODO: handle specific mapping types. e.g. Map<int, Class<?>>
+        return when {
+            response.isRedirect -> Redirection(
+                response.code,
+                response.headers.toMultimap()
+            )
+
+            response.isInformational -> Informational(
+                response.message,
+                response.code,
+                response.headers.toMultimap()
+            )
+
+            response.isSuccessful -> Success(
+                responseBody(response.body, accept),
+                response.code,
+                response.headers.toMultimap()
+            )
+
+            response.isClientError -> ClientError(
+                response.message,
+                response.body?.string(),
+                response.code,
+                response.headers.toMultimap()
+            )
+
+            else -> ServerError(
+                response.message,
+                response.body?.string(),
+                response.code,
+                response.headers.toMultimap()
+            )
+        }
+    }
+
+    protected fun parameterToString(value: Any?): String = when (value) {
+        null -> ""
+        is Array<*> -> toMultiValue(value, "csv").toString()
+        is Iterable<*> -> toMultiValue(value, "csv").toString()
+        is OffsetDateTime, is OffsetTime, is LocalDateTime, is LocalDate, is LocalTime ->
+            parseDateToQueryString(value)
+
+        else -> value.toString()
+    }
+
+    protected fun parseDateToQueryString(value: Any): String {
+        /*
+        .replace("\"", "") converts the json object string to an actual string for the query parameter.
+        The moshi or gson adapter allows a more generic solution instead of trying to use a native
+        formatter. It also easily allows to provide a simple way to define a custom date format pattern
+        inside a gson/moshi adapter.
+        */
+        return objectMapper.writeValueAsString(value).replace("\"", "")
+    }
+}
+
+└─────────────────────────────────────────────────────────────────────────┘
+
+┌───────────────────────────────────────────────────────────────────────────┐
+│ <root>/out/com/openapi/generated/api/client/infrastructure/ApiResponse.kt │
+├───────────────────────────────────────────────────────────────────────────┤
+package com.openapi.generated.api.client.infrastructure
+
+enum class ResponseType {
+    Success, Informational, Redirection, ClientError, ServerError
+}
+
+interface Response
+
+abstract class ApiResponse<T>(val responseType: ResponseType) : Response {
+    abstract val statusCode: Int
+    abstract val headers: Map<String, List<String>>
+}
+
+class Success<T>(
+    val data: T,
+    override val statusCode: Int = -1,
+    override val headers: Map<String, List<String>> = mapOf()
+) : ApiResponse<T>(ResponseType.Success)
+
+class Informational<T>(
+    val statusText: String,
+    override val statusCode: Int = -1,
+    override val headers: Map<String, List<String>> = mapOf()
+) : ApiResponse<T>(ResponseType.Informational)
+
+class Redirection<T>(
+    override val statusCode: Int = -1,
+    override val headers: Map<String, List<String>> = mapOf()
+) : ApiResponse<T>(ResponseType.Redirection)
+
+class ClientError<T>(
+    val message: String? = null,
+    val body: Any? = null,
+    override val statusCode: Int = -1,
+    override val headers: Map<String, List<String>> = mapOf()
+) : ApiResponse<T>(ResponseType.ClientError)
+
+class ServerError<T>(
+    val message: String? = null,
+    val body: Any? = null,
+    override val statusCode: Int = -1,
+    override val headers: Map<String, List<String>>
+) : ApiResponse<T>(ResponseType.ServerError)
+
+└───────────────────────────────────────────────────────────────────────────┘
+
+┌──────────────────────────────────────────────────────────────────────┐
+│ <root>/out/com/openapi/generated/api/client/infrastructure/Errors.kt │
+├──────────────────────────────────────────────────────────────────────┤
+@file:Suppress("unused")
+
+package com.openapi.generated.api.client.infrastructure
+
+import java.lang.RuntimeException
+
+open class ClientException(message: kotlin.String? = null, val statusCode: Int = -1, val response: Response? = null) :
+    RuntimeException(message) {
+
+    companion object {
+        private const val serialVersionUID: Long = 123L
+    }
+}
+
+open class ServerException(message: kotlin.String? = null, val statusCode: Int = -1, val response: Response? = null) :
+    RuntimeException(message) {
+
+    companion object {
+        private const val serialVersionUID: Long = 456L
+    }
+}
+
+└──────────────────────────────────────────────────────────────────────┘
+
+┌──────────────────────────────────────────────────────────────────────────┐
+│ <root>/out/com/openapi/generated/api/client/infrastructure/PartConfig.kt │
+├──────────────────────────────────────────────────────────────────────────┤
+package com.openapi.generated.api.client.infrastructure
+
+/**
+ * Defines a config object for a given part of a multi-part request.
+ * NOTE: Headers is a Map<String,String> because rfc2616 defines
+ *       multi-valued headers as csv-only.
+ */
+data class PartConfig<T>(
+    val headers: MutableMap<String, String> = mutableMapOf(),
+    val body: T? = null
+)
+
+└──────────────────────────────────────────────────────────────────────────┘
+
+┌─────────────────────────────────────────────────────────────────────────────┐
+│ <root>/out/com/openapi/generated/api/client/infrastructure/RequestConfig.kt │
+├─────────────────────────────────────────────────────────────────────────────┤
+package com.openapi.generated.api.client.infrastructure
+
+/**
+ * Defines a config object for a given request.
+ * NOTE: This object doesn't include 'body' because it
+ *       allows for caching of the constructed object
+ *       for many request definitions.
+ * NOTE: Headers is a Map<String,String> because rfc2616 defines
+ *       multi-valued headers as csv-only.
+ */
+data class RequestConfig<T>(
+    val method: RequestMethod,
+    val path: String,
+    val headers: MutableMap<String, String> = mutableMapOf(),
+    val query: MutableMap<String, List<String>> = mutableMapOf(),
+    val requiresAuthentication: Boolean,
+    val body: T? = null
+)
+
+└─────────────────────────────────────────────────────────────────────────────┘
+
+┌─────────────────────────────────────────────────────────────────────────────┐
+│ <root>/out/com/openapi/generated/api/client/infrastructure/RequestMethod.kt │
+├─────────────────────────────────────────────────────────────────────────────┤
+package com.openapi.generated.api.client.infrastructure
+
+/**
+ * Provides enumerated HTTP verbs
+ */
+enum class RequestMethod {
+    GET, DELETE, HEAD, OPTIONS, PATCH, POST, PUT
+}
+
+└─────────────────────────────────────────────────────────────────────────────┘
+
+┌──────────────────────────────────────────────────────────────────────────────────┐
+│ <root>/out/com/openapi/generated/api/client/infrastructure/ResponseExtensions.kt │
+├──────────────────────────────────────────────────────────────────────────────────┤
+package com.openapi.generated.api.client.infrastructure
+
+import okhttp3.Response
+
+/**
+ * Provides an extension to evaluation whether the response is a 1xx code
+ */
+val Response.isInformational: Boolean get() = this.code in 100..199
+
+/**
+ * Provides an extension to evaluation whether the response is a 3xx code
+ */
+@Suppress("EXTENSION_SHADOWED_BY_MEMBER")
+val Response.isRedirect: Boolean get() = this.code in 300..399
+
+/**
+ * Provides an extension to evaluation whether the response is a 4xx code
+ */
+val Response.isClientError: Boolean get() = this.code in 400..499
+
+/**
+ * Provides an extension to evaluation whether the response is a 5xx (Standard) through 999 (non-standard) code
+ */
+val Response.isServerError: Boolean get() = this.code in 500..999
+
+└──────────────────────────────────────────────────────────────────────────────────┘
+
+┌──────────────────────────────────────────────────────────────────────────┐
+│ <root>/out/com/openapi/generated/api/client/infrastructure/Serializer.kt │
+├──────────────────────────────────────────────────────────────────────────┤
+package com.openapi.generated.api.client.infrastructure
+
+import com.fasterxml.jackson.annotation.JsonInclude
+import tools.jackson.databind.DeserializationFeature
+import tools.jackson.databind.ObjectMapper
+import tools.jackson.databind.SerializationFeature
+import tools.jackson.module.kotlin.jacksonMapperBuilder
+
+object Serializer {
+    val jacksonObjectMapper: ObjectMapper = run {
+        jacksonMapperBuilder()
+            .findAndAddModules()
+            .changeDefaultPropertyInclusion { it.withValueInclusion(JsonInclude.Include.NON_ABSENT).withContentInclusion(JsonInclude.Include.NON_ABSENT) }
+            .configure(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS, false)
+            .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
+            .build()
+    }
+}
+
+└──────────────────────────────────────────────────────────────────────────┘

--- a/packages/kotlin/tests/.verify/openapi-services/okhttp-3-clients-spring-boot-4.expect.txt
+++ b/packages/kotlin/tests/.verify/openapi-services/okhttp-3-clients-spring-boot-4.expect.txt
@@ -678,7 +678,6 @@ import okhttp3.RequestBody
 import okhttp3.RequestBody.Companion.asRequestBody
 import okhttp3.RequestBody.Companion.toRequestBody
 import okhttp3.ResponseBody
-import okhttp3.internal.EMPTY_REQUEST
 import java.io.File
 import java.net.URLConnection
 import java.time.LocalDate
@@ -770,7 +769,7 @@ open class ApiClient(val baseUrl: String, val client: Factory = defaultClient, v
 
             mediaType == null || mediaType.startsWith("application/") && mediaType.endsWith("json") ->
                 if (content == null) {
-                    EMPTY_REQUEST
+                    ByteArray(0).toRequestBody(null)
                 } else {
                     objectMapper.writeValueAsString(content)
                         .toRequestBody((mediaType ?: JsonMediaType).toMediaTypeOrNull())

--- a/packages/kotlin/tests/.verify/openapi-services/spring-controllers-spring-boot-3.expect.txt
+++ b/packages/kotlin/tests/.verify/openapi-services/spring-controllers-spring-boot-3.expect.txt
@@ -1,0 +1,457 @@
+┌──────────────────────────────────────┐
+│ state                                │
+├──────────────────────────────────────┤
+{
+  kotlin: {
+    models: {
+      'schema-1': {
+        __source__: '<root>/test/openapi-files/v3/service-endpoints.yml#/paths//pets/get/responses/200/content/application/json/schema',
+        type: KtReference {
+          classReference: false,
+          generics: [
+            KtReference {
+              classReference: false,
+              generics: [],
+              inject: {},
+              name: 'Pet',
+              nullable: false,
+              packageName: 'com.openapi.generated.model',
+              subReference: null
+            }
+          ],
+          inject: {},
+          name: 'List',
+          nullable: false,
+          packageName: 'kotlin.collections',
+          subReference: null
+        }
+      },
+      'schema-10': {
+        __source__: '<root>/test/openapi-files/v3/service-endpoints.yml#/components/schemas/Pet',
+        type: KtReference {
+          classReference: false,
+          generics: [],
+          inject: {},
+          name: 'Pet',
+          nullable: false,
+          packageName: 'com.openapi.generated.model',
+          subReference: null
+        }
+      },
+      'schema-11': {
+        __source__: '<root>/test/openapi-files/v3/service-endpoints.yml#/paths//pets/{id}/delete/parameters/0/schema',
+        type: KtReference {
+          classReference: false,
+          generics: [],
+          inject: {},
+          name: 'String',
+          nullable: false,
+          packageName: 'kotlin',
+          subReference: null
+        }
+      },
+      'schema-12': {
+        __source__: '<root>/test/openapi-files/v3/service-endpoints.yml#/components/schemas/Pet',
+        type: KtReference {
+          classReference: false,
+          generics: [],
+          inject: {},
+          name: 'Pet',
+          nullable: false,
+          packageName: 'com.openapi.generated.model',
+          subReference: null
+        }
+      },
+      'schema-13': {
+        __source__: '<root>/test/openapi-files/v3/service-endpoints.yml#/components/schemas/Owner',
+        type: KtReference {
+          classReference: false,
+          generics: [],
+          inject: {},
+          name: 'Owner',
+          nullable: false,
+          packageName: 'com.openapi.generated.model',
+          subReference: null
+        }
+      },
+      'schema-14': {
+        __source__: '<root>/test/openapi-files/v3/service-endpoints.yml#/components/schemas/Owner',
+        type: KtReference {
+          classReference: false,
+          generics: [],
+          inject: {},
+          name: 'Owner',
+          nullable: false,
+          packageName: 'com.openapi.generated.model',
+          subReference: null
+        }
+      },
+      'schema-15': {
+        __source__: '<root>/test/openapi-files/v3/service-endpoints.yml#/components/schemas/Owner/properties/name',
+        type: KtReference {
+          classReference: false,
+          generics: [],
+          inject: {},
+          name: 'String',
+          nullable: false,
+          packageName: 'kotlin',
+          subReference: null
+        }
+      },
+      'schema-2': {
+        __source__: '<root>/test/openapi-files/v3/service-endpoints.yml#/components/schemas/Pet',
+        type: KtReference {
+          classReference: false,
+          generics: [],
+          inject: {},
+          name: 'Pet',
+          nullable: false,
+          packageName: 'com.openapi.generated.model',
+          subReference: null
+        }
+      },
+      'schema-3': {
+        __source__: '<root>/test/openapi-files/v3/service-endpoints.yml#/components/schemas/Pet',
+        type: KtReference {
+          classReference: false,
+          generics: [],
+          inject: {},
+          name: 'Pet',
+          nullable: false,
+          packageName: 'com.openapi.generated.model',
+          subReference: null
+        }
+      },
+      'schema-4': {
+        __source__: '<root>/test/openapi-files/v3/service-endpoints.yml#/components/schemas/Pet/properties/id',
+        type: KtReference {
+          classReference: false,
+          generics: [],
+          inject: {},
+          name: 'String',
+          nullable: false,
+          packageName: 'kotlin',
+          subReference: null
+        }
+      },
+      'schema-5': {
+        __source__: '<root>/test/openapi-files/v3/service-endpoints.yml#/components/schemas/Pet/properties/name',
+        type: KtReference {
+          classReference: false,
+          generics: [],
+          inject: {},
+          name: 'String',
+          nullable: false,
+          packageName: 'kotlin',
+          subReference: null
+        }
+      },
+      'schema-6': {
+        __source__: '<root>/test/openapi-files/v3/service-endpoints.yml#/components/schemas/Pet/properties/tag',
+        type: KtReference {
+          classReference: false,
+          generics: [],
+          inject: {},
+          name: 'String',
+          nullable: false,
+          packageName: 'kotlin',
+          subReference: null
+        }
+      },
+      'schema-7': {
+        __source__: '<root>/test/openapi-files/v3/service-endpoints.yml#/components/schemas/Pet',
+        type: KtReference {
+          classReference: false,
+          generics: [],
+          inject: {},
+          name: 'Pet',
+          nullable: false,
+          packageName: 'com.openapi.generated.model',
+          subReference: null
+        }
+      },
+      'schema-8': {
+        __source__: '<root>/test/openapi-files/v3/service-endpoints.yml#/components/schemas/Pet',
+        type: KtReference {
+          classReference: false,
+          generics: [],
+          inject: {},
+          name: 'Pet',
+          nullable: false,
+          packageName: 'com.openapi.generated.model',
+          subReference: null
+        }
+      },
+      'schema-9': {
+        __source__: '<root>/test/openapi-files/v3/service-endpoints.yml#/paths//pets/{id}/get/parameters/0/schema',
+        type: KtReference {
+          classReference: false,
+          generics: [],
+          inject: {},
+          name: 'String',
+          nullable: false,
+          packageName: 'kotlin',
+          subReference: null
+        }
+      }
+    },
+    services: {
+      'service-1': {
+        __source__: 'tag:Pets',
+        apiController: {
+          packageName: 'com.openapi.generated.api',
+          typeName: 'PetsApiController'
+        },
+        apiDelegate: {
+          packageName: 'com.openapi.generated.api',
+          typeName: 'PetsApiDelegate'
+        },
+        apiInterface: {
+          packageName: 'com.openapi.generated.api',
+          typeName: 'PetsApi'
+        }
+      }
+    }
+  }
+}
+└──────────────────────────────────────┘
+
+┌────────────────────────────────────────┐
+│ out/com/openapi/generated/model/Pet.kt │
+├────────────────────────────────────────┤
+package com.openapi.generated.model
+
+import com.fasterxml.jackson.annotation.JsonProperty
+import io.swagger.v3.oas.annotations.media.Schema
+
+data class Pet(
+    @Schema(required = true)
+    @param:JsonProperty("id", required = true)
+    @get:JsonProperty("id", required = true)
+    val id: String,
+
+    @Schema(required = true)
+    @param:JsonProperty("name", required = true)
+    @get:JsonProperty("name", required = true)
+    val name: String,
+
+    @Schema
+    @param:JsonProperty("tag")
+    @get:JsonProperty("tag")
+    val tag: String? = null
+)
+
+└────────────────────────────────────────┘
+
+┌──────────────────────────────────────────┐
+│ out/com/openapi/generated/model/Owner.kt │
+├──────────────────────────────────────────┤
+package com.openapi.generated.model
+
+import com.fasterxml.jackson.annotation.JsonProperty
+import io.swagger.v3.oas.annotations.media.Schema
+
+data class Owner(
+    @Schema(required = true)
+    @param:JsonProperty("name", required = true)
+    @get:JsonProperty("name", required = true)
+    val name: String
+)
+
+└──────────────────────────────────────────┘
+
+┌──────────────────────────────────────────┐
+│ out/com/openapi/generated/api/PetsApi.kt │
+├──────────────────────────────────────────┤
+package com.openapi.generated.api
+
+import com.openapi.generated.model.Owner
+import com.openapi.generated.model.Pet
+import io.swagger.v3.oas.annotations.media.ArraySchema
+import io.swagger.v3.oas.annotations.media.Content
+import io.swagger.v3.oas.annotations.media.Schema
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.Parameter
+import io.swagger.v3.oas.annotations.responses.ApiResponse
+import io.swagger.v3.oas.annotations.responses.ApiResponses
+import jakarta.validation.Valid
+import org.springframework.http.ResponseEntity
+import org.springframework.validation.annotation.Validated
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestMethod
+
+@Validated
+@RequestMapping("\${api.base-path:/}")
+interface PetsApi {
+    companion object {
+        const val LIST_PETS_PATH = "/pets"
+        const val CREATE_PET_PATH = "/pets"
+        const val GET_PET_PATH = "/pets/{id}"
+        const val DELETE_PET_PATH = "/pets/{id}"
+        const val SEARCH_PETS_PATH = "/pets/search"
+    }
+
+    fun getDelegate(): PetsApiDelegate = object : PetsApiDelegate {}
+
+    fun getExceptionHandler(): ApiExceptionHandler? = null
+
+    @Operation(operationId = "listPets", deprecated = false)
+    @ApiResponses(value = [ApiResponse(responseCode = "200", description = "A list of pets.", content = [Content(mediaType = "application/json", array = ArraySchema(schema = Schema(implementation = Pet::class)))])])
+    @RequestMapping(method = [RequestMethod.GET], value = [LIST_PETS_PATH])
+    suspend fun listPets(): ResponseEntity<*> {
+        try {
+            return getDelegate().listPets()
+        } catch (e: Throwable) {
+            return getExceptionHandler()?.handleApiException(e) ?: throw e
+        }
+    }
+
+    @Operation(operationId = "createPet", deprecated = false)
+    @ApiResponses(value = [ApiResponse(responseCode = "201", description = "The created pet.", content = [Content(mediaType = "application/json", schema = Schema(implementation = Pet::class))]), ApiResponse(responseCode = "400", description = "Invalid input.", content = [Content()])])
+    @RequestMapping(method = [RequestMethod.POST], value = [CREATE_PET_PATH], consumes = ["application/json"])
+    suspend fun createPet(
+        @Parameter(required = true)
+        @Valid
+        @RequestBody
+        pet: Pet
+    ): ResponseEntity<*> {
+        try {
+            return getDelegate().createPet(pet)
+        } catch (e: Throwable) {
+            return getExceptionHandler()?.handleApiException(e) ?: throw e
+        }
+    }
+
+    @Operation(operationId = "getPet", deprecated = false)
+    @ApiResponses(value = [ApiResponse(responseCode = "200", description = "The requested pet.", content = [Content(mediaType = "application/json", schema = Schema(implementation = Pet::class))]), ApiResponse(responseCode = "404", description = "Pet not found.", content = [Content()])])
+    @RequestMapping(method = [RequestMethod.GET], value = [GET_PET_PATH])
+    suspend fun getPet(
+        @Parameter(required = true)
+        @PathVariable("id")
+        id: String
+    ): ResponseEntity<*> {
+        try {
+            return getDelegate().getPet(id)
+        } catch (e: Throwable) {
+            return getExceptionHandler()?.handleApiException(e) ?: throw e
+        }
+    }
+
+    @Operation(operationId = "deletePet", deprecated = false)
+    @ApiResponses(value = [ApiResponse(responseCode = "204", description = "Pet deleted.", content = [Content()])])
+    @RequestMapping(method = [RequestMethod.DELETE], value = [DELETE_PET_PATH])
+    suspend fun deletePet(
+        @Parameter(required = true)
+        @PathVariable("id")
+        id: String
+    ): ResponseEntity<*> {
+        try {
+            return getDelegate().deletePet(id)
+        } catch (e: Throwable) {
+            return getExceptionHandler()?.handleApiException(e) ?: throw e
+        }
+    }
+
+    @Operation(operationId = "searchPets", deprecated = false)
+    @ApiResponses(value = [ApiResponse(responseCode = "200", description = "A pet.", content = [Content(mediaType = "application/json", schema = Schema(implementation = Pet::class))]), ApiResponse(responseCode = "202", description = "An owner.", content = [Content(mediaType = "application/json", schema = Schema(implementation = Owner::class))])])
+    @RequestMapping(method = [RequestMethod.GET], value = [SEARCH_PETS_PATH])
+    suspend fun searchPets(): ResponseEntity<*> {
+        try {
+            return getDelegate().searchPets()
+        } catch (e: Throwable) {
+            return getExceptionHandler()?.handleApiException(e) ?: throw e
+        }
+    }
+}
+
+└──────────────────────────────────────────┘
+
+┌────────────────────────────────────────────────────┐
+│ out/com/openapi/generated/api/PetsApiController.kt │
+├────────────────────────────────────────────────────┤
+package com.openapi.generated.api
+
+import jakarta.annotation.Generated
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.stereotype.Controller
+import org.springframework.web.bind.annotation.RequestMapping
+
+@Generated(value = ["com.goast.kotlin.spring-service-generator"])
+@Controller
+@RequestMapping("\${openapi.pets.base-path:/}")
+class PetsApiController(
+    @Autowired(required = false)
+    delegate: PetsApiDelegate?,
+
+    @Autowired(required = false)
+    private val exceptionHandler: ApiExceptionHandler?
+) : PetsApi {
+    private val delegate = delegate ?: object : PetsApiDelegate {}
+
+    override fun getDelegate(): PetsApiDelegate = delegate
+
+    override fun getExceptionHandler(): ApiExceptionHandler? = exceptionHandler
+}
+
+└────────────────────────────────────────────────────┘
+
+┌──────────────────────────────────────────────────┐
+│ out/com/openapi/generated/api/PetsApiDelegate.kt │
+├──────────────────────────────────────────────────┤
+package com.openapi.generated.api
+
+import com.openapi.generated.model.Pet
+import jakarta.annotation.Generated
+import org.springframework.http.HttpStatus
+import org.springframework.http.ResponseEntity
+import org.springframework.web.context.request.NativeWebRequest
+import reactor.core.publisher.Flux
+import java.util.Optional
+
+@Generated(value = ["com.goast.kotlin.spring-service-generator"])
+interface PetsApiDelegate {
+    fun getRequest(): Optional<NativeWebRequest> = Optional.empty()
+
+    suspend fun listPets(): ResponseEntity<Flux<Pet>> {
+        return ResponseEntity(HttpStatus.NOT_IMPLEMENTED)
+    }
+
+    suspend fun createPet(pet: Pet): ResponseEntity<Pet> {
+        return ResponseEntity(HttpStatus.NOT_IMPLEMENTED)
+    }
+
+    suspend fun getPet(id: String): ResponseEntity<Pet> {
+        return ResponseEntity(HttpStatus.NOT_IMPLEMENTED)
+    }
+
+    suspend fun deletePet(id: String): ResponseEntity<Unit> {
+        return ResponseEntity(HttpStatus.NOT_IMPLEMENTED)
+    }
+
+    suspend fun searchPets(): ResponseEntity<Any?> {
+        return ResponseEntity(HttpStatus.NOT_IMPLEMENTED)
+    }
+}
+
+└──────────────────────────────────────────────────┘
+
+┌──────────────────────────────────────────────────────┐
+│ out/com/openapi/generated/api/ApiExceptionHandler.kt │
+├──────────────────────────────────────────────────────┤
+package com.openapi.generated.api
+
+import org.springframework.http.ResponseEntity
+
+interface ApiExceptionHandler {
+    /**
+     * Handler for API exceptions.
+     *
+     * @param exception Exception that has been thrown by the API.
+     * @return Response entity.
+     */
+    suspend fun handleApiException(exception: Throwable): ResponseEntity<*>
+}
+
+└──────────────────────────────────────────────────────┘

--- a/packages/kotlin/tests/.verify/openapi-services/spring-controllers-spring-boot-4.expect.txt
+++ b/packages/kotlin/tests/.verify/openapi-services/spring-controllers-spring-boot-4.expect.txt
@@ -1,0 +1,457 @@
+┌──────────────────────────────────────┐
+│ state                                │
+├──────────────────────────────────────┤
+{
+  kotlin: {
+    models: {
+      'schema-1': {
+        __source__: '<root>/test/openapi-files/v3/service-endpoints.yml#/paths//pets/get/responses/200/content/application/json/schema',
+        type: KtReference {
+          classReference: false,
+          generics: [
+            KtReference {
+              classReference: false,
+              generics: [],
+              inject: {},
+              name: 'Pet',
+              nullable: false,
+              packageName: 'com.openapi.generated.model',
+              subReference: null
+            }
+          ],
+          inject: {},
+          name: 'List',
+          nullable: false,
+          packageName: 'kotlin.collections',
+          subReference: null
+        }
+      },
+      'schema-10': {
+        __source__: '<root>/test/openapi-files/v3/service-endpoints.yml#/components/schemas/Pet',
+        type: KtReference {
+          classReference: false,
+          generics: [],
+          inject: {},
+          name: 'Pet',
+          nullable: false,
+          packageName: 'com.openapi.generated.model',
+          subReference: null
+        }
+      },
+      'schema-11': {
+        __source__: '<root>/test/openapi-files/v3/service-endpoints.yml#/paths//pets/{id}/delete/parameters/0/schema',
+        type: KtReference {
+          classReference: false,
+          generics: [],
+          inject: {},
+          name: 'String',
+          nullable: false,
+          packageName: 'kotlin',
+          subReference: null
+        }
+      },
+      'schema-12': {
+        __source__: '<root>/test/openapi-files/v3/service-endpoints.yml#/components/schemas/Pet',
+        type: KtReference {
+          classReference: false,
+          generics: [],
+          inject: {},
+          name: 'Pet',
+          nullable: false,
+          packageName: 'com.openapi.generated.model',
+          subReference: null
+        }
+      },
+      'schema-13': {
+        __source__: '<root>/test/openapi-files/v3/service-endpoints.yml#/components/schemas/Owner',
+        type: KtReference {
+          classReference: false,
+          generics: [],
+          inject: {},
+          name: 'Owner',
+          nullable: false,
+          packageName: 'com.openapi.generated.model',
+          subReference: null
+        }
+      },
+      'schema-14': {
+        __source__: '<root>/test/openapi-files/v3/service-endpoints.yml#/components/schemas/Owner',
+        type: KtReference {
+          classReference: false,
+          generics: [],
+          inject: {},
+          name: 'Owner',
+          nullable: false,
+          packageName: 'com.openapi.generated.model',
+          subReference: null
+        }
+      },
+      'schema-15': {
+        __source__: '<root>/test/openapi-files/v3/service-endpoints.yml#/components/schemas/Owner/properties/name',
+        type: KtReference {
+          classReference: false,
+          generics: [],
+          inject: {},
+          name: 'String',
+          nullable: false,
+          packageName: 'kotlin',
+          subReference: null
+        }
+      },
+      'schema-2': {
+        __source__: '<root>/test/openapi-files/v3/service-endpoints.yml#/components/schemas/Pet',
+        type: KtReference {
+          classReference: false,
+          generics: [],
+          inject: {},
+          name: 'Pet',
+          nullable: false,
+          packageName: 'com.openapi.generated.model',
+          subReference: null
+        }
+      },
+      'schema-3': {
+        __source__: '<root>/test/openapi-files/v3/service-endpoints.yml#/components/schemas/Pet',
+        type: KtReference {
+          classReference: false,
+          generics: [],
+          inject: {},
+          name: 'Pet',
+          nullable: false,
+          packageName: 'com.openapi.generated.model',
+          subReference: null
+        }
+      },
+      'schema-4': {
+        __source__: '<root>/test/openapi-files/v3/service-endpoints.yml#/components/schemas/Pet/properties/id',
+        type: KtReference {
+          classReference: false,
+          generics: [],
+          inject: {},
+          name: 'String',
+          nullable: false,
+          packageName: 'kotlin',
+          subReference: null
+        }
+      },
+      'schema-5': {
+        __source__: '<root>/test/openapi-files/v3/service-endpoints.yml#/components/schemas/Pet/properties/name',
+        type: KtReference {
+          classReference: false,
+          generics: [],
+          inject: {},
+          name: 'String',
+          nullable: false,
+          packageName: 'kotlin',
+          subReference: null
+        }
+      },
+      'schema-6': {
+        __source__: '<root>/test/openapi-files/v3/service-endpoints.yml#/components/schemas/Pet/properties/tag',
+        type: KtReference {
+          classReference: false,
+          generics: [],
+          inject: {},
+          name: 'String',
+          nullable: false,
+          packageName: 'kotlin',
+          subReference: null
+        }
+      },
+      'schema-7': {
+        __source__: '<root>/test/openapi-files/v3/service-endpoints.yml#/components/schemas/Pet',
+        type: KtReference {
+          classReference: false,
+          generics: [],
+          inject: {},
+          name: 'Pet',
+          nullable: false,
+          packageName: 'com.openapi.generated.model',
+          subReference: null
+        }
+      },
+      'schema-8': {
+        __source__: '<root>/test/openapi-files/v3/service-endpoints.yml#/components/schemas/Pet',
+        type: KtReference {
+          classReference: false,
+          generics: [],
+          inject: {},
+          name: 'Pet',
+          nullable: false,
+          packageName: 'com.openapi.generated.model',
+          subReference: null
+        }
+      },
+      'schema-9': {
+        __source__: '<root>/test/openapi-files/v3/service-endpoints.yml#/paths//pets/{id}/get/parameters/0/schema',
+        type: KtReference {
+          classReference: false,
+          generics: [],
+          inject: {},
+          name: 'String',
+          nullable: false,
+          packageName: 'kotlin',
+          subReference: null
+        }
+      }
+    },
+    services: {
+      'service-1': {
+        __source__: 'tag:Pets',
+        apiController: {
+          packageName: 'com.openapi.generated.api',
+          typeName: 'PetsApiController'
+        },
+        apiDelegate: {
+          packageName: 'com.openapi.generated.api',
+          typeName: 'PetsApiDelegate'
+        },
+        apiInterface: {
+          packageName: 'com.openapi.generated.api',
+          typeName: 'PetsApi'
+        }
+      }
+    }
+  }
+}
+└──────────────────────────────────────┘
+
+┌────────────────────────────────────────┐
+│ out/com/openapi/generated/model/Pet.kt │
+├────────────────────────────────────────┤
+package com.openapi.generated.model
+
+import com.fasterxml.jackson.annotation.JsonProperty
+import io.swagger.v3.oas.annotations.media.Schema
+
+data class Pet(
+    @Schema(required = true)
+    @param:JsonProperty("id", required = true)
+    @get:JsonProperty("id", required = true)
+    val id: String,
+
+    @Schema(required = true)
+    @param:JsonProperty("name", required = true)
+    @get:JsonProperty("name", required = true)
+    val name: String,
+
+    @Schema
+    @param:JsonProperty("tag")
+    @get:JsonProperty("tag")
+    val tag: String? = null
+)
+
+└────────────────────────────────────────┘
+
+┌──────────────────────────────────────────┐
+│ out/com/openapi/generated/model/Owner.kt │
+├──────────────────────────────────────────┤
+package com.openapi.generated.model
+
+import com.fasterxml.jackson.annotation.JsonProperty
+import io.swagger.v3.oas.annotations.media.Schema
+
+data class Owner(
+    @Schema(required = true)
+    @param:JsonProperty("name", required = true)
+    @get:JsonProperty("name", required = true)
+    val name: String
+)
+
+└──────────────────────────────────────────┘
+
+┌──────────────────────────────────────────┐
+│ out/com/openapi/generated/api/PetsApi.kt │
+├──────────────────────────────────────────┤
+package com.openapi.generated.api
+
+import com.openapi.generated.model.Owner
+import com.openapi.generated.model.Pet
+import io.swagger.v3.oas.annotations.media.ArraySchema
+import io.swagger.v3.oas.annotations.media.Content
+import io.swagger.v3.oas.annotations.media.Schema
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.Parameter
+import io.swagger.v3.oas.annotations.responses.ApiResponse
+import io.swagger.v3.oas.annotations.responses.ApiResponses
+import jakarta.validation.Valid
+import org.springframework.http.ResponseEntity
+import org.springframework.validation.annotation.Validated
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestMethod
+
+@Validated
+@RequestMapping("\${api.base-path:/}")
+interface PetsApi {
+    companion object {
+        const val LIST_PETS_PATH = "/pets"
+        const val CREATE_PET_PATH = "/pets"
+        const val GET_PET_PATH = "/pets/{id}"
+        const val DELETE_PET_PATH = "/pets/{id}"
+        const val SEARCH_PETS_PATH = "/pets/search"
+    }
+
+    fun getDelegate(): PetsApiDelegate = object : PetsApiDelegate {}
+
+    fun getExceptionHandler(): ApiExceptionHandler? = null
+
+    @Operation(operationId = "listPets", deprecated = false)
+    @ApiResponses(value = [ApiResponse(responseCode = "200", description = "A list of pets.", content = [Content(mediaType = "application/json", array = ArraySchema(schema = Schema(implementation = Pet::class)))])])
+    @RequestMapping(method = [RequestMethod.GET], value = [LIST_PETS_PATH])
+    suspend fun listPets(): ResponseEntity<*> {
+        try {
+            return getDelegate().listPets()
+        } catch (e: Throwable) {
+            return getExceptionHandler()?.handleApiException(e) ?: throw e
+        }
+    }
+
+    @Operation(operationId = "createPet", deprecated = false)
+    @ApiResponses(value = [ApiResponse(responseCode = "201", description = "The created pet.", content = [Content(mediaType = "application/json", schema = Schema(implementation = Pet::class))]), ApiResponse(responseCode = "400", description = "Invalid input.", content = [Content()])])
+    @RequestMapping(method = [RequestMethod.POST], value = [CREATE_PET_PATH], consumes = ["application/json"])
+    suspend fun createPet(
+        @Parameter(required = true)
+        @Valid
+        @RequestBody
+        pet: Pet
+    ): ResponseEntity<*> {
+        try {
+            return getDelegate().createPet(pet)
+        } catch (e: Throwable) {
+            return getExceptionHandler()?.handleApiException(e) ?: throw e
+        }
+    }
+
+    @Operation(operationId = "getPet", deprecated = false)
+    @ApiResponses(value = [ApiResponse(responseCode = "200", description = "The requested pet.", content = [Content(mediaType = "application/json", schema = Schema(implementation = Pet::class))]), ApiResponse(responseCode = "404", description = "Pet not found.", content = [Content()])])
+    @RequestMapping(method = [RequestMethod.GET], value = [GET_PET_PATH])
+    suspend fun getPet(
+        @Parameter(required = true)
+        @PathVariable("id")
+        id: String
+    ): ResponseEntity<*> {
+        try {
+            return getDelegate().getPet(id)
+        } catch (e: Throwable) {
+            return getExceptionHandler()?.handleApiException(e) ?: throw e
+        }
+    }
+
+    @Operation(operationId = "deletePet", deprecated = false)
+    @ApiResponses(value = [ApiResponse(responseCode = "204", description = "Pet deleted.", content = [Content()])])
+    @RequestMapping(method = [RequestMethod.DELETE], value = [DELETE_PET_PATH])
+    suspend fun deletePet(
+        @Parameter(required = true)
+        @PathVariable("id")
+        id: String
+    ): ResponseEntity<*> {
+        try {
+            return getDelegate().deletePet(id)
+        } catch (e: Throwable) {
+            return getExceptionHandler()?.handleApiException(e) ?: throw e
+        }
+    }
+
+    @Operation(operationId = "searchPets", deprecated = false)
+    @ApiResponses(value = [ApiResponse(responseCode = "200", description = "A pet.", content = [Content(mediaType = "application/json", schema = Schema(implementation = Pet::class))]), ApiResponse(responseCode = "202", description = "An owner.", content = [Content(mediaType = "application/json", schema = Schema(implementation = Owner::class))])])
+    @RequestMapping(method = [RequestMethod.GET], value = [SEARCH_PETS_PATH])
+    suspend fun searchPets(): ResponseEntity<*> {
+        try {
+            return getDelegate().searchPets()
+        } catch (e: Throwable) {
+            return getExceptionHandler()?.handleApiException(e) ?: throw e
+        }
+    }
+}
+
+└──────────────────────────────────────────┘
+
+┌────────────────────────────────────────────────────┐
+│ out/com/openapi/generated/api/PetsApiController.kt │
+├────────────────────────────────────────────────────┤
+package com.openapi.generated.api
+
+import jakarta.annotation.Generated
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.stereotype.Controller
+import org.springframework.web.bind.annotation.RequestMapping
+
+@Generated(value = ["com.goast.kotlin.spring-service-generator"])
+@Controller
+@RequestMapping("\${openapi.pets.base-path:/}")
+class PetsApiController(
+    @Autowired(required = false)
+    delegate: PetsApiDelegate?,
+
+    @Autowired(required = false)
+    private val exceptionHandler: ApiExceptionHandler?
+) : PetsApi {
+    private val delegate = delegate ?: object : PetsApiDelegate {}
+
+    override fun getDelegate(): PetsApiDelegate = delegate
+
+    override fun getExceptionHandler(): ApiExceptionHandler? = exceptionHandler
+}
+
+└────────────────────────────────────────────────────┘
+
+┌──────────────────────────────────────────────────┐
+│ out/com/openapi/generated/api/PetsApiDelegate.kt │
+├──────────────────────────────────────────────────┤
+package com.openapi.generated.api
+
+import com.openapi.generated.model.Pet
+import jakarta.annotation.Generated
+import org.springframework.http.HttpStatus
+import org.springframework.http.ResponseEntity
+import org.springframework.web.context.request.NativeWebRequest
+import reactor.core.publisher.Flux
+import java.util.Optional
+
+@Generated(value = ["com.goast.kotlin.spring-service-generator"])
+interface PetsApiDelegate {
+    fun getRequest(): Optional<NativeWebRequest> = Optional.empty()
+
+    suspend fun listPets(): ResponseEntity<Flux<Pet>> {
+        return ResponseEntity(HttpStatus.NOT_IMPLEMENTED)
+    }
+
+    suspend fun createPet(pet: Pet): ResponseEntity<Pet> {
+        return ResponseEntity(HttpStatus.NOT_IMPLEMENTED)
+    }
+
+    suspend fun getPet(id: String): ResponseEntity<Pet> {
+        return ResponseEntity(HttpStatus.NOT_IMPLEMENTED)
+    }
+
+    suspend fun deletePet(id: String): ResponseEntity<Unit> {
+        return ResponseEntity(HttpStatus.NOT_IMPLEMENTED)
+    }
+
+    suspend fun searchPets(): ResponseEntity<Any> {
+        return ResponseEntity(HttpStatus.NOT_IMPLEMENTED)
+    }
+}
+
+└──────────────────────────────────────────────────┘
+
+┌──────────────────────────────────────────────────────┐
+│ out/com/openapi/generated/api/ApiExceptionHandler.kt │
+├──────────────────────────────────────────────────────┤
+package com.openapi.generated.api
+
+import org.springframework.http.ResponseEntity
+
+interface ApiExceptionHandler {
+    /**
+     * Handler for API exceptions.
+     *
+     * @param exception Exception that has been thrown by the API.
+     * @return Response entity.
+     */
+    suspend fun handleApiException(exception: Throwable): ResponseEntity<*>
+}
+
+└──────────────────────────────────────────────────────┘

--- a/packages/kotlin/tests/.verify/openapi-services/spring-controllers-strict-response-entities-spring-boot-3.expect.txt
+++ b/packages/kotlin/tests/.verify/openapi-services/spring-controllers-strict-response-entities-spring-boot-3.expect.txt
@@ -1,0 +1,606 @@
+┌──────────────────────────────────────┐
+│ state                                │
+├──────────────────────────────────────┤
+{
+  kotlin: {
+    models: {
+      'schema-1': {
+        __source__: '<root>/test/openapi-files/v3/service-endpoints.yml#/paths//pets/get/responses/200/content/application/json/schema',
+        type: KtReference {
+          classReference: false,
+          generics: [
+            KtReference {
+              classReference: false,
+              generics: [],
+              inject: {},
+              name: 'Pet',
+              nullable: false,
+              packageName: 'com.openapi.generated.model',
+              subReference: null
+            }
+          ],
+          inject: {},
+          name: 'List',
+          nullable: false,
+          packageName: 'kotlin.collections',
+          subReference: null
+        }
+      },
+      'schema-10': {
+        __source__: '<root>/test/openapi-files/v3/service-endpoints.yml#/components/schemas/Pet',
+        type: KtReference {
+          classReference: false,
+          generics: [],
+          inject: {},
+          name: 'Pet',
+          nullable: false,
+          packageName: 'com.openapi.generated.model',
+          subReference: null
+        }
+      },
+      'schema-11': {
+        __source__: '<root>/test/openapi-files/v3/service-endpoints.yml#/paths//pets/{id}/delete/parameters/0/schema',
+        type: KtReference {
+          classReference: false,
+          generics: [],
+          inject: {},
+          name: 'String',
+          nullable: false,
+          packageName: 'kotlin',
+          subReference: null
+        }
+      },
+      'schema-12': {
+        __source__: '<root>/test/openapi-files/v3/service-endpoints.yml#/components/schemas/Pet',
+        type: KtReference {
+          classReference: false,
+          generics: [],
+          inject: {},
+          name: 'Pet',
+          nullable: false,
+          packageName: 'com.openapi.generated.model',
+          subReference: null
+        }
+      },
+      'schema-13': {
+        __source__: '<root>/test/openapi-files/v3/service-endpoints.yml#/components/schemas/Owner',
+        type: KtReference {
+          classReference: false,
+          generics: [],
+          inject: {},
+          name: 'Owner',
+          nullable: false,
+          packageName: 'com.openapi.generated.model',
+          subReference: null
+        }
+      },
+      'schema-14': {
+        __source__: '<root>/test/openapi-files/v3/service-endpoints.yml#/components/schemas/Owner',
+        type: KtReference {
+          classReference: false,
+          generics: [],
+          inject: {},
+          name: 'Owner',
+          nullable: false,
+          packageName: 'com.openapi.generated.model',
+          subReference: null
+        }
+      },
+      'schema-15': {
+        __source__: '<root>/test/openapi-files/v3/service-endpoints.yml#/components/schemas/Owner/properties/name',
+        type: KtReference {
+          classReference: false,
+          generics: [],
+          inject: {},
+          name: 'String',
+          nullable: false,
+          packageName: 'kotlin',
+          subReference: null
+        }
+      },
+      'schema-2': {
+        __source__: '<root>/test/openapi-files/v3/service-endpoints.yml#/components/schemas/Pet',
+        type: KtReference {
+          classReference: false,
+          generics: [],
+          inject: {},
+          name: 'Pet',
+          nullable: false,
+          packageName: 'com.openapi.generated.model',
+          subReference: null
+        }
+      },
+      'schema-3': {
+        __source__: '<root>/test/openapi-files/v3/service-endpoints.yml#/components/schemas/Pet',
+        type: KtReference {
+          classReference: false,
+          generics: [],
+          inject: {},
+          name: 'Pet',
+          nullable: false,
+          packageName: 'com.openapi.generated.model',
+          subReference: null
+        }
+      },
+      'schema-4': {
+        __source__: '<root>/test/openapi-files/v3/service-endpoints.yml#/components/schemas/Pet/properties/id',
+        type: KtReference {
+          classReference: false,
+          generics: [],
+          inject: {},
+          name: 'String',
+          nullable: false,
+          packageName: 'kotlin',
+          subReference: null
+        }
+      },
+      'schema-5': {
+        __source__: '<root>/test/openapi-files/v3/service-endpoints.yml#/components/schemas/Pet/properties/name',
+        type: KtReference {
+          classReference: false,
+          generics: [],
+          inject: {},
+          name: 'String',
+          nullable: false,
+          packageName: 'kotlin',
+          subReference: null
+        }
+      },
+      'schema-6': {
+        __source__: '<root>/test/openapi-files/v3/service-endpoints.yml#/components/schemas/Pet/properties/tag',
+        type: KtReference {
+          classReference: false,
+          generics: [],
+          inject: {},
+          name: 'String',
+          nullable: false,
+          packageName: 'kotlin',
+          subReference: null
+        }
+      },
+      'schema-7': {
+        __source__: '<root>/test/openapi-files/v3/service-endpoints.yml#/components/schemas/Pet',
+        type: KtReference {
+          classReference: false,
+          generics: [],
+          inject: {},
+          name: 'Pet',
+          nullable: false,
+          packageName: 'com.openapi.generated.model',
+          subReference: null
+        }
+      },
+      'schema-8': {
+        __source__: '<root>/test/openapi-files/v3/service-endpoints.yml#/components/schemas/Pet',
+        type: KtReference {
+          classReference: false,
+          generics: [],
+          inject: {},
+          name: 'Pet',
+          nullable: false,
+          packageName: 'com.openapi.generated.model',
+          subReference: null
+        }
+      },
+      'schema-9': {
+        __source__: '<root>/test/openapi-files/v3/service-endpoints.yml#/paths//pets/{id}/get/parameters/0/schema',
+        type: KtReference {
+          classReference: false,
+          generics: [],
+          inject: {},
+          name: 'String',
+          nullable: false,
+          packageName: 'kotlin',
+          subReference: null
+        }
+      }
+    },
+    services: {
+      'service-1': {
+        __source__: 'tag:Pets',
+        apiController: {
+          packageName: 'com.openapi.generated.api',
+          typeName: 'PetsApiController'
+        },
+        apiDelegate: {
+          packageName: 'com.openapi.generated.api',
+          typeName: 'PetsApiDelegate'
+        },
+        apiInterface: {
+          packageName: 'com.openapi.generated.api',
+          typeName: 'PetsApi'
+        }
+      }
+    }
+  }
+}
+└──────────────────────────────────────┘
+
+┌────────────────────────────────────────┐
+│ out/com/openapi/generated/model/Pet.kt │
+├────────────────────────────────────────┤
+package com.openapi.generated.model
+
+import com.fasterxml.jackson.annotation.JsonProperty
+import io.swagger.v3.oas.annotations.media.Schema
+
+data class Pet(
+    @Schema(required = true)
+    @param:JsonProperty("id", required = true)
+    @get:JsonProperty("id", required = true)
+    val id: String,
+
+    @Schema(required = true)
+    @param:JsonProperty("name", required = true)
+    @get:JsonProperty("name", required = true)
+    val name: String,
+
+    @Schema
+    @param:JsonProperty("tag")
+    @get:JsonProperty("tag")
+    val tag: String? = null
+)
+
+└────────────────────────────────────────┘
+
+┌──────────────────────────────────────────┐
+│ out/com/openapi/generated/model/Owner.kt │
+├──────────────────────────────────────────┤
+package com.openapi.generated.model
+
+import com.fasterxml.jackson.annotation.JsonProperty
+import io.swagger.v3.oas.annotations.media.Schema
+
+data class Owner(
+    @Schema(required = true)
+    @param:JsonProperty("name", required = true)
+    @get:JsonProperty("name", required = true)
+    val name: String
+)
+
+└──────────────────────────────────────────┘
+
+┌──────────────────────────────────────────┐
+│ out/com/openapi/generated/api/PetsApi.kt │
+├──────────────────────────────────────────┤
+package com.openapi.generated.api
+
+import com.openapi.generated.model.Owner
+import com.openapi.generated.model.Pet
+import io.swagger.v3.oas.annotations.media.ArraySchema
+import io.swagger.v3.oas.annotations.media.Content
+import io.swagger.v3.oas.annotations.media.Schema
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.Parameter
+import io.swagger.v3.oas.annotations.responses.ApiResponse
+import io.swagger.v3.oas.annotations.responses.ApiResponses
+import jakarta.validation.Valid
+import org.springframework.http.ResponseEntity
+import org.springframework.util.LinkedMultiValueMap
+import org.springframework.util.MultiValueMap
+import org.springframework.validation.annotation.Validated
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestMethod
+import reactor.core.publisher.Flux
+
+@Validated
+@RequestMapping("\${api.base-path:/}")
+interface PetsApi {
+    companion object {
+        const val LIST_PETS_PATH = "/pets"
+        const val CREATE_PET_PATH = "/pets"
+        const val GET_PET_PATH = "/pets/{id}"
+        const val DELETE_PET_PATH = "/pets/{id}"
+        const val SEARCH_PETS_PATH = "/pets/search"
+    }
+
+    fun getDelegate(): PetsApiDelegate = object : PetsApiDelegate {}
+
+    fun getExceptionHandler(): ApiExceptionHandler? = null
+
+    @Operation(operationId = "listPets", deprecated = false)
+    @ApiResponses(value = [ApiResponse(responseCode = "200", description = "A list of pets.", content = [Content(mediaType = "application/json", array = ArraySchema(schema = Schema(implementation = Pet::class)))])])
+    @RequestMapping(method = [RequestMethod.GET], value = [LIST_PETS_PATH])
+    suspend fun listPets(): ResponseEntity<*> {
+        try {
+            return getDelegate().listPets()
+        } catch (e: Throwable) {
+            return getExceptionHandler()?.handleApiException(e) ?: throw e
+        }
+    }
+
+    @Operation(operationId = "createPet", deprecated = false)
+    @ApiResponses(value = [ApiResponse(responseCode = "201", description = "The created pet.", content = [Content(mediaType = "application/json", schema = Schema(implementation = Pet::class))]), ApiResponse(responseCode = "400", description = "Invalid input.", content = [Content()])])
+    @RequestMapping(method = [RequestMethod.POST], value = [CREATE_PET_PATH], consumes = ["application/json"])
+    suspend fun createPet(
+        @Parameter(required = true)
+        @Valid
+        @RequestBody
+        pet: Pet
+    ): ResponseEntity<*> {
+        try {
+            return getDelegate().createPet(pet)
+        } catch (e: Throwable) {
+            return getExceptionHandler()?.handleApiException(e) ?: throw e
+        }
+    }
+
+    @Operation(operationId = "getPet", deprecated = false)
+    @ApiResponses(value = [ApiResponse(responseCode = "200", description = "The requested pet.", content = [Content(mediaType = "application/json", schema = Schema(implementation = Pet::class))]), ApiResponse(responseCode = "404", description = "Pet not found.", content = [Content()])])
+    @RequestMapping(method = [RequestMethod.GET], value = [GET_PET_PATH])
+    suspend fun getPet(
+        @Parameter(required = true)
+        @PathVariable("id")
+        id: String
+    ): ResponseEntity<*> {
+        try {
+            return getDelegate().getPet(id)
+        } catch (e: Throwable) {
+            return getExceptionHandler()?.handleApiException(e) ?: throw e
+        }
+    }
+
+    @Operation(operationId = "deletePet", deprecated = false)
+    @ApiResponses(value = [ApiResponse(responseCode = "204", description = "Pet deleted.", content = [Content()])])
+    @RequestMapping(method = [RequestMethod.DELETE], value = [DELETE_PET_PATH])
+    suspend fun deletePet(
+        @Parameter(required = true)
+        @PathVariable("id")
+        id: String
+    ): ResponseEntity<*> {
+        try {
+            return getDelegate().deletePet(id)
+        } catch (e: Throwable) {
+            return getExceptionHandler()?.handleApiException(e) ?: throw e
+        }
+    }
+
+    @Operation(operationId = "searchPets", deprecated = false)
+    @ApiResponses(value = [ApiResponse(responseCode = "200", description = "A pet.", content = [Content(mediaType = "application/json", schema = Schema(implementation = Pet::class))]), ApiResponse(responseCode = "202", description = "An owner.", content = [Content(mediaType = "application/json", schema = Schema(implementation = Owner::class))])])
+    @RequestMapping(method = [RequestMethod.GET], value = [SEARCH_PETS_PATH])
+    suspend fun searchPets(): ResponseEntity<*> {
+        try {
+            return getDelegate().searchPets()
+        } catch (e: Throwable) {
+            return getExceptionHandler()?.handleApiException(e) ?: throw e
+        }
+    }
+
+    /**
+     * Response entity for listPets.
+     */
+    class ListPetsResponseEntity<T> private constructor(
+        body: T,
+        rawStatus: Int,
+        headers: MultiValueMap<String, String>? = null
+    ) : ResponseEntity<T>(body, headers, rawStatus) {
+        companion object {
+            fun badRequest(headers: MultiValueMap<String, String>? = null) = ListPetsResponseEntity<Unit?>(null, 400, headers)
+
+            fun unauthorized(headers: MultiValueMap<String, String>? = null) = ListPetsResponseEntity<Unit?>(null, 401, headers)
+
+            fun forbidden(headers: MultiValueMap<String, String>? = null) = ListPetsResponseEntity<Unit?>(null, 403, headers)
+
+            fun internalServerError(headers: MultiValueMap<String, String>? = null) = ListPetsResponseEntity<Unit?>(null, 500, headers)
+
+            fun notImplemented(headers: MultiValueMap<String, String>? = null) = ListPetsResponseEntity<Unit?>(null, 501, headers)
+
+            fun ok(body: Flux<Pet>, headers: MultiValueMap<String, String>? = null) = ListPetsResponseEntity<Flux<Pet>>(body, 200, LinkedMultiValueMap<String, String>().also {
+                        if (headers != null) {
+                            it.putAll(headers)
+                        }
+                        it.addIfAbsent("Content-Type", "application/json")
+                    })
+        }
+    }
+
+    /**
+     * Response entity for createPet.
+     */
+    class CreatePetResponseEntity<T> private constructor(
+        body: T,
+        rawStatus: Int,
+        headers: MultiValueMap<String, String>? = null
+    ) : ResponseEntity<T>(body, headers, rawStatus) {
+        companion object {
+            fun badRequest(headers: MultiValueMap<String, String>? = null) = CreatePetResponseEntity<Unit?>(null, 400, headers)
+
+            fun unauthorized(headers: MultiValueMap<String, String>? = null) = CreatePetResponseEntity<Unit?>(null, 401, headers)
+
+            fun forbidden(headers: MultiValueMap<String, String>? = null) = CreatePetResponseEntity<Unit?>(null, 403, headers)
+
+            fun internalServerError(headers: MultiValueMap<String, String>? = null) = CreatePetResponseEntity<Unit?>(null, 500, headers)
+
+            fun notImplemented(headers: MultiValueMap<String, String>? = null) = CreatePetResponseEntity<Unit?>(null, 501, headers)
+
+            fun created(body: Pet, headers: MultiValueMap<String, String>? = null) = CreatePetResponseEntity<Pet>(body, 201, LinkedMultiValueMap<String, String>().also {
+                        if (headers != null) {
+                            it.putAll(headers)
+                        }
+                        it.addIfAbsent("Content-Type", "application/json")
+                    })
+        }
+    }
+
+    /**
+     * Response entity for getPet.
+     */
+    class GetPetResponseEntity<T> private constructor(
+        body: T,
+        rawStatus: Int,
+        headers: MultiValueMap<String, String>? = null
+    ) : ResponseEntity<T>(body, headers, rawStatus) {
+        companion object {
+            fun badRequest(headers: MultiValueMap<String, String>? = null) = GetPetResponseEntity<Unit?>(null, 400, headers)
+
+            fun unauthorized(headers: MultiValueMap<String, String>? = null) = GetPetResponseEntity<Unit?>(null, 401, headers)
+
+            fun forbidden(headers: MultiValueMap<String, String>? = null) = GetPetResponseEntity<Unit?>(null, 403, headers)
+
+            fun internalServerError(headers: MultiValueMap<String, String>? = null) = GetPetResponseEntity<Unit?>(null, 500, headers)
+
+            fun notImplemented(headers: MultiValueMap<String, String>? = null) = GetPetResponseEntity<Unit?>(null, 501, headers)
+
+            fun ok(body: Pet, headers: MultiValueMap<String, String>? = null) = GetPetResponseEntity<Pet>(body, 200, LinkedMultiValueMap<String, String>().also {
+                        if (headers != null) {
+                            it.putAll(headers)
+                        }
+                        it.addIfAbsent("Content-Type", "application/json")
+                    })
+
+            fun notFound(headers: MultiValueMap<String, String>? = null) = GetPetResponseEntity<Unit?>(null, 404, headers)
+        }
+    }
+
+    /**
+     * Response entity for deletePet.
+     */
+    class DeletePetResponseEntity<T> private constructor(
+        body: T,
+        rawStatus: Int,
+        headers: MultiValueMap<String, String>? = null
+    ) : ResponseEntity<T>(body, headers, rawStatus) {
+        companion object {
+            fun badRequest(headers: MultiValueMap<String, String>? = null) = DeletePetResponseEntity<Unit?>(null, 400, headers)
+
+            fun unauthorized(headers: MultiValueMap<String, String>? = null) = DeletePetResponseEntity<Unit?>(null, 401, headers)
+
+            fun forbidden(headers: MultiValueMap<String, String>? = null) = DeletePetResponseEntity<Unit?>(null, 403, headers)
+
+            fun internalServerError(headers: MultiValueMap<String, String>? = null) = DeletePetResponseEntity<Unit?>(null, 500, headers)
+
+            fun notImplemented(headers: MultiValueMap<String, String>? = null) = DeletePetResponseEntity<Unit?>(null, 501, headers)
+
+            fun noContent(headers: MultiValueMap<String, String>? = null) = DeletePetResponseEntity<Unit?>(null, 204, headers)
+        }
+    }
+
+    /**
+     * Response entity for searchPets.
+     */
+    class SearchPetsResponseEntity<T> private constructor(
+        body: T,
+        rawStatus: Int,
+        headers: MultiValueMap<String, String>? = null
+    ) : ResponseEntity<T>(body, headers, rawStatus) {
+        companion object {
+            fun badRequest(headers: MultiValueMap<String, String>? = null) = SearchPetsResponseEntity<Unit?>(null, 400, headers)
+
+            fun unauthorized(headers: MultiValueMap<String, String>? = null) = SearchPetsResponseEntity<Unit?>(null, 401, headers)
+
+            fun forbidden(headers: MultiValueMap<String, String>? = null) = SearchPetsResponseEntity<Unit?>(null, 403, headers)
+
+            fun internalServerError(headers: MultiValueMap<String, String>? = null) = SearchPetsResponseEntity<Unit?>(null, 500, headers)
+
+            fun notImplemented(headers: MultiValueMap<String, String>? = null) = SearchPetsResponseEntity<Unit?>(null, 501, headers)
+
+            fun ok(body: Pet, headers: MultiValueMap<String, String>? = null) = SearchPetsResponseEntity<Pet>(body, 200, LinkedMultiValueMap<String, String>().also {
+                        if (headers != null) {
+                            it.putAll(headers)
+                        }
+                        it.addIfAbsent("Content-Type", "application/json")
+                    })
+
+            fun accepted(body: Owner, headers: MultiValueMap<String, String>? = null) = SearchPetsResponseEntity<Owner>(body, 202, LinkedMultiValueMap<String, String>().also {
+                        if (headers != null) {
+                            it.putAll(headers)
+                        }
+                        it.addIfAbsent("Content-Type", "application/json")
+                    })
+        }
+    }
+}
+
+└──────────────────────────────────────────┘
+
+┌────────────────────────────────────────────────────┐
+│ out/com/openapi/generated/api/PetsApiController.kt │
+├────────────────────────────────────────────────────┤
+package com.openapi.generated.api
+
+import jakarta.annotation.Generated
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.stereotype.Controller
+import org.springframework.web.bind.annotation.RequestMapping
+
+@Generated(value = ["com.goast.kotlin.spring-service-generator"])
+@Controller
+@RequestMapping("\${openapi.pets.base-path:/}")
+class PetsApiController(
+    @Autowired(required = false)
+    delegate: PetsApiDelegate?,
+
+    @Autowired(required = false)
+    private val exceptionHandler: ApiExceptionHandler?
+) : PetsApi {
+    private val delegate = delegate ?: object : PetsApiDelegate {}
+
+    override fun getDelegate(): PetsApiDelegate = delegate
+
+    override fun getExceptionHandler(): ApiExceptionHandler? = exceptionHandler
+}
+
+└────────────────────────────────────────────────────┘
+
+┌──────────────────────────────────────────────────┐
+│ out/com/openapi/generated/api/PetsApiDelegate.kt │
+├──────────────────────────────────────────────────┤
+package com.openapi.generated.api
+
+import com.openapi.generated.api.PetsApi.CreatePetResponseEntity
+import com.openapi.generated.api.PetsApi.DeletePetResponseEntity
+import com.openapi.generated.api.PetsApi.GetPetResponseEntity
+import com.openapi.generated.api.PetsApi.ListPetsResponseEntity
+import com.openapi.generated.api.PetsApi.SearchPetsResponseEntity
+import com.openapi.generated.model.Pet
+import jakarta.annotation.Generated
+import org.springframework.web.context.request.NativeWebRequest
+import java.util.Optional
+
+@Generated(value = ["com.goast.kotlin.spring-service-generator"])
+interface PetsApiDelegate {
+    fun getRequest(): Optional<NativeWebRequest> = Optional.empty()
+
+    suspend fun listPets(): ListPetsResponseEntity<*> {
+        return ListPetsResponseEntity.notImplemented()
+    }
+
+    suspend fun createPet(pet: Pet): CreatePetResponseEntity<*> {
+        return CreatePetResponseEntity.notImplemented()
+    }
+
+    suspend fun getPet(id: String): GetPetResponseEntity<*> {
+        return GetPetResponseEntity.notImplemented()
+    }
+
+    suspend fun deletePet(id: String): DeletePetResponseEntity<*> {
+        return DeletePetResponseEntity.notImplemented()
+    }
+
+    suspend fun searchPets(): SearchPetsResponseEntity<*> {
+        return SearchPetsResponseEntity.notImplemented()
+    }
+}
+
+└──────────────────────────────────────────────────┘
+
+┌──────────────────────────────────────────────────────┐
+│ out/com/openapi/generated/api/ApiExceptionHandler.kt │
+├──────────────────────────────────────────────────────┤
+package com.openapi.generated.api
+
+import org.springframework.http.ResponseEntity
+
+interface ApiExceptionHandler {
+    /**
+     * Handler for API exceptions.
+     *
+     * @param exception Exception that has been thrown by the API.
+     * @return Response entity.
+     */
+    suspend fun handleApiException(exception: Throwable): ResponseEntity<*>
+}
+
+└──────────────────────────────────────────────────────┘

--- a/packages/kotlin/tests/.verify/openapi-services/spring-controllers-strict-response-entities-spring-boot-4.expect.txt
+++ b/packages/kotlin/tests/.verify/openapi-services/spring-controllers-strict-response-entities-spring-boot-4.expect.txt
@@ -1,0 +1,606 @@
+┌──────────────────────────────────────┐
+│ state                                │
+├──────────────────────────────────────┤
+{
+  kotlin: {
+    models: {
+      'schema-1': {
+        __source__: '<root>/test/openapi-files/v3/service-endpoints.yml#/paths//pets/get/responses/200/content/application/json/schema',
+        type: KtReference {
+          classReference: false,
+          generics: [
+            KtReference {
+              classReference: false,
+              generics: [],
+              inject: {},
+              name: 'Pet',
+              nullable: false,
+              packageName: 'com.openapi.generated.model',
+              subReference: null
+            }
+          ],
+          inject: {},
+          name: 'List',
+          nullable: false,
+          packageName: 'kotlin.collections',
+          subReference: null
+        }
+      },
+      'schema-10': {
+        __source__: '<root>/test/openapi-files/v3/service-endpoints.yml#/components/schemas/Pet',
+        type: KtReference {
+          classReference: false,
+          generics: [],
+          inject: {},
+          name: 'Pet',
+          nullable: false,
+          packageName: 'com.openapi.generated.model',
+          subReference: null
+        }
+      },
+      'schema-11': {
+        __source__: '<root>/test/openapi-files/v3/service-endpoints.yml#/paths//pets/{id}/delete/parameters/0/schema',
+        type: KtReference {
+          classReference: false,
+          generics: [],
+          inject: {},
+          name: 'String',
+          nullable: false,
+          packageName: 'kotlin',
+          subReference: null
+        }
+      },
+      'schema-12': {
+        __source__: '<root>/test/openapi-files/v3/service-endpoints.yml#/components/schemas/Pet',
+        type: KtReference {
+          classReference: false,
+          generics: [],
+          inject: {},
+          name: 'Pet',
+          nullable: false,
+          packageName: 'com.openapi.generated.model',
+          subReference: null
+        }
+      },
+      'schema-13': {
+        __source__: '<root>/test/openapi-files/v3/service-endpoints.yml#/components/schemas/Owner',
+        type: KtReference {
+          classReference: false,
+          generics: [],
+          inject: {},
+          name: 'Owner',
+          nullable: false,
+          packageName: 'com.openapi.generated.model',
+          subReference: null
+        }
+      },
+      'schema-14': {
+        __source__: '<root>/test/openapi-files/v3/service-endpoints.yml#/components/schemas/Owner',
+        type: KtReference {
+          classReference: false,
+          generics: [],
+          inject: {},
+          name: 'Owner',
+          nullable: false,
+          packageName: 'com.openapi.generated.model',
+          subReference: null
+        }
+      },
+      'schema-15': {
+        __source__: '<root>/test/openapi-files/v3/service-endpoints.yml#/components/schemas/Owner/properties/name',
+        type: KtReference {
+          classReference: false,
+          generics: [],
+          inject: {},
+          name: 'String',
+          nullable: false,
+          packageName: 'kotlin',
+          subReference: null
+        }
+      },
+      'schema-2': {
+        __source__: '<root>/test/openapi-files/v3/service-endpoints.yml#/components/schemas/Pet',
+        type: KtReference {
+          classReference: false,
+          generics: [],
+          inject: {},
+          name: 'Pet',
+          nullable: false,
+          packageName: 'com.openapi.generated.model',
+          subReference: null
+        }
+      },
+      'schema-3': {
+        __source__: '<root>/test/openapi-files/v3/service-endpoints.yml#/components/schemas/Pet',
+        type: KtReference {
+          classReference: false,
+          generics: [],
+          inject: {},
+          name: 'Pet',
+          nullable: false,
+          packageName: 'com.openapi.generated.model',
+          subReference: null
+        }
+      },
+      'schema-4': {
+        __source__: '<root>/test/openapi-files/v3/service-endpoints.yml#/components/schemas/Pet/properties/id',
+        type: KtReference {
+          classReference: false,
+          generics: [],
+          inject: {},
+          name: 'String',
+          nullable: false,
+          packageName: 'kotlin',
+          subReference: null
+        }
+      },
+      'schema-5': {
+        __source__: '<root>/test/openapi-files/v3/service-endpoints.yml#/components/schemas/Pet/properties/name',
+        type: KtReference {
+          classReference: false,
+          generics: [],
+          inject: {},
+          name: 'String',
+          nullable: false,
+          packageName: 'kotlin',
+          subReference: null
+        }
+      },
+      'schema-6': {
+        __source__: '<root>/test/openapi-files/v3/service-endpoints.yml#/components/schemas/Pet/properties/tag',
+        type: KtReference {
+          classReference: false,
+          generics: [],
+          inject: {},
+          name: 'String',
+          nullable: false,
+          packageName: 'kotlin',
+          subReference: null
+        }
+      },
+      'schema-7': {
+        __source__: '<root>/test/openapi-files/v3/service-endpoints.yml#/components/schemas/Pet',
+        type: KtReference {
+          classReference: false,
+          generics: [],
+          inject: {},
+          name: 'Pet',
+          nullable: false,
+          packageName: 'com.openapi.generated.model',
+          subReference: null
+        }
+      },
+      'schema-8': {
+        __source__: '<root>/test/openapi-files/v3/service-endpoints.yml#/components/schemas/Pet',
+        type: KtReference {
+          classReference: false,
+          generics: [],
+          inject: {},
+          name: 'Pet',
+          nullable: false,
+          packageName: 'com.openapi.generated.model',
+          subReference: null
+        }
+      },
+      'schema-9': {
+        __source__: '<root>/test/openapi-files/v3/service-endpoints.yml#/paths//pets/{id}/get/parameters/0/schema',
+        type: KtReference {
+          classReference: false,
+          generics: [],
+          inject: {},
+          name: 'String',
+          nullable: false,
+          packageName: 'kotlin',
+          subReference: null
+        }
+      }
+    },
+    services: {
+      'service-1': {
+        __source__: 'tag:Pets',
+        apiController: {
+          packageName: 'com.openapi.generated.api',
+          typeName: 'PetsApiController'
+        },
+        apiDelegate: {
+          packageName: 'com.openapi.generated.api',
+          typeName: 'PetsApiDelegate'
+        },
+        apiInterface: {
+          packageName: 'com.openapi.generated.api',
+          typeName: 'PetsApi'
+        }
+      }
+    }
+  }
+}
+└──────────────────────────────────────┘
+
+┌────────────────────────────────────────┐
+│ out/com/openapi/generated/model/Pet.kt │
+├────────────────────────────────────────┤
+package com.openapi.generated.model
+
+import com.fasterxml.jackson.annotation.JsonProperty
+import io.swagger.v3.oas.annotations.media.Schema
+
+data class Pet(
+    @Schema(required = true)
+    @param:JsonProperty("id", required = true)
+    @get:JsonProperty("id", required = true)
+    val id: String,
+
+    @Schema(required = true)
+    @param:JsonProperty("name", required = true)
+    @get:JsonProperty("name", required = true)
+    val name: String,
+
+    @Schema
+    @param:JsonProperty("tag")
+    @get:JsonProperty("tag")
+    val tag: String? = null
+)
+
+└────────────────────────────────────────┘
+
+┌──────────────────────────────────────────┐
+│ out/com/openapi/generated/model/Owner.kt │
+├──────────────────────────────────────────┤
+package com.openapi.generated.model
+
+import com.fasterxml.jackson.annotation.JsonProperty
+import io.swagger.v3.oas.annotations.media.Schema
+
+data class Owner(
+    @Schema(required = true)
+    @param:JsonProperty("name", required = true)
+    @get:JsonProperty("name", required = true)
+    val name: String
+)
+
+└──────────────────────────────────────────┘
+
+┌──────────────────────────────────────────┐
+│ out/com/openapi/generated/api/PetsApi.kt │
+├──────────────────────────────────────────┤
+package com.openapi.generated.api
+
+import com.openapi.generated.model.Owner
+import com.openapi.generated.model.Pet
+import io.swagger.v3.oas.annotations.media.ArraySchema
+import io.swagger.v3.oas.annotations.media.Content
+import io.swagger.v3.oas.annotations.media.Schema
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.Parameter
+import io.swagger.v3.oas.annotations.responses.ApiResponse
+import io.swagger.v3.oas.annotations.responses.ApiResponses
+import jakarta.validation.Valid
+import org.springframework.http.ResponseEntity
+import org.springframework.util.LinkedMultiValueMap
+import org.springframework.util.MultiValueMap
+import org.springframework.validation.annotation.Validated
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestMethod
+import reactor.core.publisher.Flux
+
+@Validated
+@RequestMapping("\${api.base-path:/}")
+interface PetsApi {
+    companion object {
+        const val LIST_PETS_PATH = "/pets"
+        const val CREATE_PET_PATH = "/pets"
+        const val GET_PET_PATH = "/pets/{id}"
+        const val DELETE_PET_PATH = "/pets/{id}"
+        const val SEARCH_PETS_PATH = "/pets/search"
+    }
+
+    fun getDelegate(): PetsApiDelegate = object : PetsApiDelegate {}
+
+    fun getExceptionHandler(): ApiExceptionHandler? = null
+
+    @Operation(operationId = "listPets", deprecated = false)
+    @ApiResponses(value = [ApiResponse(responseCode = "200", description = "A list of pets.", content = [Content(mediaType = "application/json", array = ArraySchema(schema = Schema(implementation = Pet::class)))])])
+    @RequestMapping(method = [RequestMethod.GET], value = [LIST_PETS_PATH])
+    suspend fun listPets(): ResponseEntity<*> {
+        try {
+            return getDelegate().listPets()
+        } catch (e: Throwable) {
+            return getExceptionHandler()?.handleApiException(e) ?: throw e
+        }
+    }
+
+    @Operation(operationId = "createPet", deprecated = false)
+    @ApiResponses(value = [ApiResponse(responseCode = "201", description = "The created pet.", content = [Content(mediaType = "application/json", schema = Schema(implementation = Pet::class))]), ApiResponse(responseCode = "400", description = "Invalid input.", content = [Content()])])
+    @RequestMapping(method = [RequestMethod.POST], value = [CREATE_PET_PATH], consumes = ["application/json"])
+    suspend fun createPet(
+        @Parameter(required = true)
+        @Valid
+        @RequestBody
+        pet: Pet
+    ): ResponseEntity<*> {
+        try {
+            return getDelegate().createPet(pet)
+        } catch (e: Throwable) {
+            return getExceptionHandler()?.handleApiException(e) ?: throw e
+        }
+    }
+
+    @Operation(operationId = "getPet", deprecated = false)
+    @ApiResponses(value = [ApiResponse(responseCode = "200", description = "The requested pet.", content = [Content(mediaType = "application/json", schema = Schema(implementation = Pet::class))]), ApiResponse(responseCode = "404", description = "Pet not found.", content = [Content()])])
+    @RequestMapping(method = [RequestMethod.GET], value = [GET_PET_PATH])
+    suspend fun getPet(
+        @Parameter(required = true)
+        @PathVariable("id")
+        id: String
+    ): ResponseEntity<*> {
+        try {
+            return getDelegate().getPet(id)
+        } catch (e: Throwable) {
+            return getExceptionHandler()?.handleApiException(e) ?: throw e
+        }
+    }
+
+    @Operation(operationId = "deletePet", deprecated = false)
+    @ApiResponses(value = [ApiResponse(responseCode = "204", description = "Pet deleted.", content = [Content()])])
+    @RequestMapping(method = [RequestMethod.DELETE], value = [DELETE_PET_PATH])
+    suspend fun deletePet(
+        @Parameter(required = true)
+        @PathVariable("id")
+        id: String
+    ): ResponseEntity<*> {
+        try {
+            return getDelegate().deletePet(id)
+        } catch (e: Throwable) {
+            return getExceptionHandler()?.handleApiException(e) ?: throw e
+        }
+    }
+
+    @Operation(operationId = "searchPets", deprecated = false)
+    @ApiResponses(value = [ApiResponse(responseCode = "200", description = "A pet.", content = [Content(mediaType = "application/json", schema = Schema(implementation = Pet::class))]), ApiResponse(responseCode = "202", description = "An owner.", content = [Content(mediaType = "application/json", schema = Schema(implementation = Owner::class))])])
+    @RequestMapping(method = [RequestMethod.GET], value = [SEARCH_PETS_PATH])
+    suspend fun searchPets(): ResponseEntity<*> {
+        try {
+            return getDelegate().searchPets()
+        } catch (e: Throwable) {
+            return getExceptionHandler()?.handleApiException(e) ?: throw e
+        }
+    }
+
+    /**
+     * Response entity for listPets.
+     */
+    class ListPetsResponseEntity<T : Any> private constructor(
+        body: T?,
+        rawStatus: Int,
+        headers: MultiValueMap<String, String>? = null
+    ) : ResponseEntity<T>(body, headers, rawStatus) {
+        companion object {
+            fun badRequest(headers: MultiValueMap<String, String>? = null) = ListPetsResponseEntity<Unit>(null, 400, headers)
+
+            fun unauthorized(headers: MultiValueMap<String, String>? = null) = ListPetsResponseEntity<Unit>(null, 401, headers)
+
+            fun forbidden(headers: MultiValueMap<String, String>? = null) = ListPetsResponseEntity<Unit>(null, 403, headers)
+
+            fun internalServerError(headers: MultiValueMap<String, String>? = null) = ListPetsResponseEntity<Unit>(null, 500, headers)
+
+            fun notImplemented(headers: MultiValueMap<String, String>? = null) = ListPetsResponseEntity<Unit>(null, 501, headers)
+
+            fun ok(body: Flux<Pet>, headers: MultiValueMap<String, String>? = null) = ListPetsResponseEntity<Flux<Pet>>(body, 200, LinkedMultiValueMap<String, String>().also {
+                        if (headers != null) {
+                            it.putAll(headers)
+                        }
+                        it.addIfAbsent("Content-Type", "application/json")
+                    })
+        }
+    }
+
+    /**
+     * Response entity for createPet.
+     */
+    class CreatePetResponseEntity<T : Any> private constructor(
+        body: T?,
+        rawStatus: Int,
+        headers: MultiValueMap<String, String>? = null
+    ) : ResponseEntity<T>(body, headers, rawStatus) {
+        companion object {
+            fun badRequest(headers: MultiValueMap<String, String>? = null) = CreatePetResponseEntity<Unit>(null, 400, headers)
+
+            fun unauthorized(headers: MultiValueMap<String, String>? = null) = CreatePetResponseEntity<Unit>(null, 401, headers)
+
+            fun forbidden(headers: MultiValueMap<String, String>? = null) = CreatePetResponseEntity<Unit>(null, 403, headers)
+
+            fun internalServerError(headers: MultiValueMap<String, String>? = null) = CreatePetResponseEntity<Unit>(null, 500, headers)
+
+            fun notImplemented(headers: MultiValueMap<String, String>? = null) = CreatePetResponseEntity<Unit>(null, 501, headers)
+
+            fun created(body: Pet, headers: MultiValueMap<String, String>? = null) = CreatePetResponseEntity<Pet>(body, 201, LinkedMultiValueMap<String, String>().also {
+                        if (headers != null) {
+                            it.putAll(headers)
+                        }
+                        it.addIfAbsent("Content-Type", "application/json")
+                    })
+        }
+    }
+
+    /**
+     * Response entity for getPet.
+     */
+    class GetPetResponseEntity<T : Any> private constructor(
+        body: T?,
+        rawStatus: Int,
+        headers: MultiValueMap<String, String>? = null
+    ) : ResponseEntity<T>(body, headers, rawStatus) {
+        companion object {
+            fun badRequest(headers: MultiValueMap<String, String>? = null) = GetPetResponseEntity<Unit>(null, 400, headers)
+
+            fun unauthorized(headers: MultiValueMap<String, String>? = null) = GetPetResponseEntity<Unit>(null, 401, headers)
+
+            fun forbidden(headers: MultiValueMap<String, String>? = null) = GetPetResponseEntity<Unit>(null, 403, headers)
+
+            fun internalServerError(headers: MultiValueMap<String, String>? = null) = GetPetResponseEntity<Unit>(null, 500, headers)
+
+            fun notImplemented(headers: MultiValueMap<String, String>? = null) = GetPetResponseEntity<Unit>(null, 501, headers)
+
+            fun ok(body: Pet, headers: MultiValueMap<String, String>? = null) = GetPetResponseEntity<Pet>(body, 200, LinkedMultiValueMap<String, String>().also {
+                        if (headers != null) {
+                            it.putAll(headers)
+                        }
+                        it.addIfAbsent("Content-Type", "application/json")
+                    })
+
+            fun notFound(headers: MultiValueMap<String, String>? = null) = GetPetResponseEntity<Unit>(null, 404, headers)
+        }
+    }
+
+    /**
+     * Response entity for deletePet.
+     */
+    class DeletePetResponseEntity<T : Any> private constructor(
+        body: T?,
+        rawStatus: Int,
+        headers: MultiValueMap<String, String>? = null
+    ) : ResponseEntity<T>(body, headers, rawStatus) {
+        companion object {
+            fun badRequest(headers: MultiValueMap<String, String>? = null) = DeletePetResponseEntity<Unit>(null, 400, headers)
+
+            fun unauthorized(headers: MultiValueMap<String, String>? = null) = DeletePetResponseEntity<Unit>(null, 401, headers)
+
+            fun forbidden(headers: MultiValueMap<String, String>? = null) = DeletePetResponseEntity<Unit>(null, 403, headers)
+
+            fun internalServerError(headers: MultiValueMap<String, String>? = null) = DeletePetResponseEntity<Unit>(null, 500, headers)
+
+            fun notImplemented(headers: MultiValueMap<String, String>? = null) = DeletePetResponseEntity<Unit>(null, 501, headers)
+
+            fun noContent(headers: MultiValueMap<String, String>? = null) = DeletePetResponseEntity<Unit>(null, 204, headers)
+        }
+    }
+
+    /**
+     * Response entity for searchPets.
+     */
+    class SearchPetsResponseEntity<T : Any> private constructor(
+        body: T?,
+        rawStatus: Int,
+        headers: MultiValueMap<String, String>? = null
+    ) : ResponseEntity<T>(body, headers, rawStatus) {
+        companion object {
+            fun badRequest(headers: MultiValueMap<String, String>? = null) = SearchPetsResponseEntity<Unit>(null, 400, headers)
+
+            fun unauthorized(headers: MultiValueMap<String, String>? = null) = SearchPetsResponseEntity<Unit>(null, 401, headers)
+
+            fun forbidden(headers: MultiValueMap<String, String>? = null) = SearchPetsResponseEntity<Unit>(null, 403, headers)
+
+            fun internalServerError(headers: MultiValueMap<String, String>? = null) = SearchPetsResponseEntity<Unit>(null, 500, headers)
+
+            fun notImplemented(headers: MultiValueMap<String, String>? = null) = SearchPetsResponseEntity<Unit>(null, 501, headers)
+
+            fun ok(body: Pet, headers: MultiValueMap<String, String>? = null) = SearchPetsResponseEntity<Pet>(body, 200, LinkedMultiValueMap<String, String>().also {
+                        if (headers != null) {
+                            it.putAll(headers)
+                        }
+                        it.addIfAbsent("Content-Type", "application/json")
+                    })
+
+            fun accepted(body: Owner, headers: MultiValueMap<String, String>? = null) = SearchPetsResponseEntity<Owner>(body, 202, LinkedMultiValueMap<String, String>().also {
+                        if (headers != null) {
+                            it.putAll(headers)
+                        }
+                        it.addIfAbsent("Content-Type", "application/json")
+                    })
+        }
+    }
+}
+
+└──────────────────────────────────────────┘
+
+┌────────────────────────────────────────────────────┐
+│ out/com/openapi/generated/api/PetsApiController.kt │
+├────────────────────────────────────────────────────┤
+package com.openapi.generated.api
+
+import jakarta.annotation.Generated
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.stereotype.Controller
+import org.springframework.web.bind.annotation.RequestMapping
+
+@Generated(value = ["com.goast.kotlin.spring-service-generator"])
+@Controller
+@RequestMapping("\${openapi.pets.base-path:/}")
+class PetsApiController(
+    @Autowired(required = false)
+    delegate: PetsApiDelegate?,
+
+    @Autowired(required = false)
+    private val exceptionHandler: ApiExceptionHandler?
+) : PetsApi {
+    private val delegate = delegate ?: object : PetsApiDelegate {}
+
+    override fun getDelegate(): PetsApiDelegate = delegate
+
+    override fun getExceptionHandler(): ApiExceptionHandler? = exceptionHandler
+}
+
+└────────────────────────────────────────────────────┘
+
+┌──────────────────────────────────────────────────┐
+│ out/com/openapi/generated/api/PetsApiDelegate.kt │
+├──────────────────────────────────────────────────┤
+package com.openapi.generated.api
+
+import com.openapi.generated.api.PetsApi.CreatePetResponseEntity
+import com.openapi.generated.api.PetsApi.DeletePetResponseEntity
+import com.openapi.generated.api.PetsApi.GetPetResponseEntity
+import com.openapi.generated.api.PetsApi.ListPetsResponseEntity
+import com.openapi.generated.api.PetsApi.SearchPetsResponseEntity
+import com.openapi.generated.model.Pet
+import jakarta.annotation.Generated
+import org.springframework.web.context.request.NativeWebRequest
+import java.util.Optional
+
+@Generated(value = ["com.goast.kotlin.spring-service-generator"])
+interface PetsApiDelegate {
+    fun getRequest(): Optional<NativeWebRequest> = Optional.empty()
+
+    suspend fun listPets(): ListPetsResponseEntity<*> {
+        return ListPetsResponseEntity.notImplemented()
+    }
+
+    suspend fun createPet(pet: Pet): CreatePetResponseEntity<*> {
+        return CreatePetResponseEntity.notImplemented()
+    }
+
+    suspend fun getPet(id: String): GetPetResponseEntity<*> {
+        return GetPetResponseEntity.notImplemented()
+    }
+
+    suspend fun deletePet(id: String): DeletePetResponseEntity<*> {
+        return DeletePetResponseEntity.notImplemented()
+    }
+
+    suspend fun searchPets(): SearchPetsResponseEntity<*> {
+        return SearchPetsResponseEntity.notImplemented()
+    }
+}
+
+└──────────────────────────────────────────────────┘
+
+┌──────────────────────────────────────────────────────┐
+│ out/com/openapi/generated/api/ApiExceptionHandler.kt │
+├──────────────────────────────────────────────────────┤
+package com.openapi.generated.api
+
+import org.springframework.http.ResponseEntity
+
+interface ApiExceptionHandler {
+    /**
+     * Handler for API exceptions.
+     *
+     * @param exception Exception that has been thrown by the API.
+     * @return Response entity.
+     */
+    suspend fun handleApiException(exception: Throwable): ResponseEntity<*>
+}
+
+└──────────────────────────────────────────────────────┘

--- a/packages/kotlin/tests/.verify/openapi-services/spring-reactive-web-clients-spring-boot-3.expect.txt
+++ b/packages/kotlin/tests/.verify/openapi-services/spring-reactive-web-clients-spring-boot-3.expect.txt
@@ -1,0 +1,436 @@
+┌──────────────────────────────────────┐
+│ state                                │
+├──────────────────────────────────────┤
+{
+  kotlin: {
+    clients: {
+      'service-1': {
+        __source__: 'tag:Pets',
+        packageName: 'com.openapi.generated.api.client',
+        typeName: 'PetsRequests'
+      }
+    },
+    models: {
+      'schema-1': {
+        __source__: '<root>/test/openapi-files/v3/service-endpoints.yml#/paths//pets/get/responses/200/content/application/json/schema',
+        type: KtReference {
+          classReference: false,
+          generics: [
+            KtReference {
+              classReference: false,
+              generics: [],
+              inject: {},
+              name: 'Pet',
+              nullable: false,
+              packageName: 'com.openapi.generated.model',
+              subReference: null
+            }
+          ],
+          inject: {},
+          name: 'List',
+          nullable: false,
+          packageName: 'kotlin.collections',
+          subReference: null
+        }
+      },
+      'schema-10': {
+        __source__: '<root>/test/openapi-files/v3/service-endpoints.yml#/components/schemas/Pet',
+        type: KtReference {
+          classReference: false,
+          generics: [],
+          inject: {},
+          name: 'Pet',
+          nullable: false,
+          packageName: 'com.openapi.generated.model',
+          subReference: null
+        }
+      },
+      'schema-11': {
+        __source__: '<root>/test/openapi-files/v3/service-endpoints.yml#/paths//pets/{id}/delete/parameters/0/schema',
+        type: KtReference {
+          classReference: false,
+          generics: [],
+          inject: {},
+          name: 'String',
+          nullable: false,
+          packageName: 'kotlin',
+          subReference: null
+        }
+      },
+      'schema-12': {
+        __source__: '<root>/test/openapi-files/v3/service-endpoints.yml#/components/schemas/Pet',
+        type: KtReference {
+          classReference: false,
+          generics: [],
+          inject: {},
+          name: 'Pet',
+          nullable: false,
+          packageName: 'com.openapi.generated.model',
+          subReference: null
+        }
+      },
+      'schema-13': {
+        __source__: '<root>/test/openapi-files/v3/service-endpoints.yml#/components/schemas/Owner',
+        type: KtReference {
+          classReference: false,
+          generics: [],
+          inject: {},
+          name: 'Owner',
+          nullable: false,
+          packageName: 'com.openapi.generated.model',
+          subReference: null
+        }
+      },
+      'schema-14': {
+        __source__: '<root>/test/openapi-files/v3/service-endpoints.yml#/components/schemas/Owner',
+        type: KtReference {
+          classReference: false,
+          generics: [],
+          inject: {},
+          name: 'Owner',
+          nullable: false,
+          packageName: 'com.openapi.generated.model',
+          subReference: null
+        }
+      },
+      'schema-15': {
+        __source__: '<root>/test/openapi-files/v3/service-endpoints.yml#/components/schemas/Owner/properties/name',
+        type: KtReference {
+          classReference: false,
+          generics: [],
+          inject: {},
+          name: 'String',
+          nullable: false,
+          packageName: 'kotlin',
+          subReference: null
+        }
+      },
+      'schema-2': {
+        __source__: '<root>/test/openapi-files/v3/service-endpoints.yml#/components/schemas/Pet',
+        type: KtReference {
+          classReference: false,
+          generics: [],
+          inject: {},
+          name: 'Pet',
+          nullable: false,
+          packageName: 'com.openapi.generated.model',
+          subReference: null
+        }
+      },
+      'schema-3': {
+        __source__: '<root>/test/openapi-files/v3/service-endpoints.yml#/components/schemas/Pet',
+        type: KtReference {
+          classReference: false,
+          generics: [],
+          inject: {},
+          name: 'Pet',
+          nullable: false,
+          packageName: 'com.openapi.generated.model',
+          subReference: null
+        }
+      },
+      'schema-4': {
+        __source__: '<root>/test/openapi-files/v3/service-endpoints.yml#/components/schemas/Pet/properties/id',
+        type: KtReference {
+          classReference: false,
+          generics: [],
+          inject: {},
+          name: 'String',
+          nullable: false,
+          packageName: 'kotlin',
+          subReference: null
+        }
+      },
+      'schema-5': {
+        __source__: '<root>/test/openapi-files/v3/service-endpoints.yml#/components/schemas/Pet/properties/name',
+        type: KtReference {
+          classReference: false,
+          generics: [],
+          inject: {},
+          name: 'String',
+          nullable: false,
+          packageName: 'kotlin',
+          subReference: null
+        }
+      },
+      'schema-6': {
+        __source__: '<root>/test/openapi-files/v3/service-endpoints.yml#/components/schemas/Pet/properties/tag',
+        type: KtReference {
+          classReference: false,
+          generics: [],
+          inject: {},
+          name: 'String',
+          nullable: false,
+          packageName: 'kotlin',
+          subReference: null
+        }
+      },
+      'schema-7': {
+        __source__: '<root>/test/openapi-files/v3/service-endpoints.yml#/components/schemas/Pet',
+        type: KtReference {
+          classReference: false,
+          generics: [],
+          inject: {},
+          name: 'Pet',
+          nullable: false,
+          packageName: 'com.openapi.generated.model',
+          subReference: null
+        }
+      },
+      'schema-8': {
+        __source__: '<root>/test/openapi-files/v3/service-endpoints.yml#/components/schemas/Pet',
+        type: KtReference {
+          classReference: false,
+          generics: [],
+          inject: {},
+          name: 'Pet',
+          nullable: false,
+          packageName: 'com.openapi.generated.model',
+          subReference: null
+        }
+      },
+      'schema-9': {
+        __source__: '<root>/test/openapi-files/v3/service-endpoints.yml#/paths//pets/{id}/get/parameters/0/schema',
+        type: KtReference {
+          classReference: false,
+          generics: [],
+          inject: {},
+          name: 'String',
+          nullable: false,
+          packageName: 'kotlin',
+          subReference: null
+        }
+      }
+    }
+  }
+}
+└──────────────────────────────────────┘
+
+┌────────────────────────────────────────┐
+│ out/com/openapi/generated/model/Pet.kt │
+├────────────────────────────────────────┤
+package com.openapi.generated.model
+
+import com.fasterxml.jackson.annotation.JsonProperty
+import io.swagger.v3.oas.annotations.media.Schema
+
+data class Pet(
+    @Schema(required = true)
+    @param:JsonProperty("id", required = true)
+    @get:JsonProperty("id", required = true)
+    val id: String,
+
+    @Schema(required = true)
+    @param:JsonProperty("name", required = true)
+    @get:JsonProperty("name", required = true)
+    val name: String,
+
+    @Schema
+    @param:JsonProperty("tag")
+    @get:JsonProperty("tag")
+    val tag: String? = null
+)
+
+└────────────────────────────────────────┘
+
+┌──────────────────────────────────────────┐
+│ out/com/openapi/generated/model/Owner.kt │
+├──────────────────────────────────────────┤
+package com.openapi.generated.model
+
+import com.fasterxml.jackson.annotation.JsonProperty
+import io.swagger.v3.oas.annotations.media.Schema
+
+data class Owner(
+    @Schema(required = true)
+    @param:JsonProperty("name", required = true)
+    @get:JsonProperty("name", required = true)
+    val name: String
+)
+
+└──────────────────────────────────────────┘
+
+┌──────────────────────────────────────────────────────┐
+│ out/com/openapi/generated/api/client/PetsRequests.kt │
+├──────────────────────────────────────────────────────┤
+package com.openapi.generated.api.client
+
+import com.openapi.generated.model.Pet
+import kotlinx.coroutines.reactive.awaitFirstOrNull
+import kotlinx.coroutines.reactor.mono
+import org.springframework.http.HttpMethod
+import org.springframework.http.MediaType
+import org.springframework.web.reactive.function.client.awaitBodilessEntity
+import org.springframework.web.reactive.function.client.awaitBody
+import org.springframework.web.reactive.function.client.ClientResponse
+import org.springframework.web.reactive.function.client.WebClient
+import org.springframework.web.reactive.function.client.WebClient.RequestHeadersSpec
+import org.springframework.web.util.UriComponentsBuilder
+
+object PetsRequests {
+    suspend fun WebClient.listPets(): List<Pet> {
+        return this
+            .listPetsRequest()
+            .retrieve()
+            .awaitBody<List<Pet>>()
+    }
+
+    suspend fun <T> WebClient.listPets(responseHandler: suspend (ClientResponse) -> T): T {
+        return this.listPetsRequest()
+            .exchangeToMono { mono { responseHandler(it) } }
+            .awaitFirstOrNull() as T
+    }
+
+    fun listPetsUri(): String {
+        return UriComponentsBuilder.fromPath("pets")
+            .build()
+            .toUriString()
+    }
+
+    fun WebClient.listPetsRequest(): RequestHeadersSpec<*> {
+        return this.method(HttpMethod.GET)
+            .uri(listPetsUri())
+            .accept(MediaType.APPLICATION_JSON)
+    }
+
+    suspend fun WebClient.createPet(pet: Pet): Pet {
+        return this
+            .createPetRequest(pet)
+            .retrieve()
+            .awaitBody<Pet>()
+    }
+
+    suspend fun <T> WebClient.createPet(pet: Pet, responseHandler: suspend (ClientResponse) -> T): T {
+        return this.createPetRequest(pet)
+            .exchangeToMono { mono { responseHandler(it) } }
+            .awaitFirstOrNull() as T
+    }
+
+    fun createPetUri(): String {
+        return UriComponentsBuilder.fromPath("pets")
+            .build()
+            .toUriString()
+    }
+
+    fun WebClient.createPetRequest(pet: Pet): RequestHeadersSpec<*> {
+        return this.method(HttpMethod.POST)
+            .uri(createPetUri())
+            .accept(MediaType.APPLICATION_JSON)
+            .contentType(MediaType.parseMediaType("application/json"))
+            .bodyValue(pet)
+    }
+
+    suspend fun WebClient.getPet(id: String): Pet {
+        return this
+            .getPetRequest(id)
+            .retrieve()
+            .awaitBody<Pet>()
+    }
+
+    suspend fun <T> WebClient.getPet(id: String, responseHandler: suspend (ClientResponse) -> T): T {
+        return this.getPetRequest(id)
+            .exchangeToMono { mono { responseHandler(it) } }
+            .awaitFirstOrNull() as T
+    }
+
+    fun getPetUri(id: String): String {
+        return UriComponentsBuilder.fromPath("pets/{id}")
+            .buildAndExpand(mapOf("id" to id.toString()))
+            .toUriString()
+    }
+
+    fun WebClient.getPetRequest(id: String): RequestHeadersSpec<*> {
+        return this.method(HttpMethod.GET)
+            .uri(getPetUri(id))
+            .accept(MediaType.APPLICATION_JSON)
+    }
+
+    suspend fun WebClient.deletePet(id: String): Unit {
+        this
+            .deletePetRequest(id)
+            .retrieve()
+            .awaitBodilessEntity()
+    }
+
+    suspend fun <T> WebClient.deletePet(id: String, responseHandler: suspend (ClientResponse) -> T): T {
+        return this.deletePetRequest(id)
+            .exchangeToMono { mono { responseHandler(it) } }
+            .awaitFirstOrNull() as T
+    }
+
+    fun deletePetUri(id: String): String {
+        return UriComponentsBuilder.fromPath("pets/{id}")
+            .buildAndExpand(mapOf("id" to id.toString()))
+            .toUriString()
+    }
+
+    fun WebClient.deletePetRequest(id: String): RequestHeadersSpec<*> {
+        return this.method(HttpMethod.DELETE).uri(deletePetUri(id))
+    }
+
+    suspend fun WebClient.searchPets(): Pet {
+        return this
+            .searchPetsRequest()
+            .retrieve()
+            .awaitBody<Pet>()
+    }
+
+    suspend fun <T> WebClient.searchPets(responseHandler: suspend (ClientResponse) -> T): T {
+        return this.searchPetsRequest()
+            .exchangeToMono { mono { responseHandler(it) } }
+            .awaitFirstOrNull() as T
+    }
+
+    fun searchPetsUri(): String {
+        return UriComponentsBuilder.fromPath("pets/search")
+            .build()
+            .toUriString()
+    }
+
+    fun WebClient.searchPetsRequest(): RequestHeadersSpec<*> {
+        return this.method(HttpMethod.GET)
+            .uri(searchPetsUri())
+            .accept(MediaType.APPLICATION_JSON)
+    }
+}
+
+└──────────────────────────────────────────────────────┘
+
+┌──────────────────────────────────────────────────────────────────────────────┐
+│ <root>/out/com/openapi/generated/api/client/infrastructure/ApiRequestFile.kt │
+├──────────────────────────────────────────────────────────────────────────────┤
+package com.openapi.generated.api.client.infrastructure
+
+import org.springframework.core.io.buffer.DataBuffer
+import org.springframework.http.MediaType
+import org.springframework.http.client.MultipartBodyBuilder
+import org.springframework.http.codec.multipart.FilePart
+import java.io.File
+
+interface ApiRequestFile {
+    companion object {
+        fun from(file: File): ApiRequestFile =
+            object : ApiRequestFile {
+                override fun addToBuilder(builder: MultipartBodyBuilder) {
+                    builder
+                        .part("file", file)
+                        .filename(file.name)
+                        .contentType(MediaType.APPLICATION_OCTET_STREAM)
+                }
+            }
+
+        fun from(filePart: FilePart): ApiRequestFile =
+            object : ApiRequestFile {
+                override fun addToBuilder(builder: MultipartBodyBuilder) {
+                    builder
+                        .asyncPart("file", filePart.content(), DataBuffer::class.java)
+                        .filename(filePart.filename())
+                        .contentType(filePart.headers().contentType ?: MediaType.APPLICATION_OCTET_STREAM)
+                }
+            }
+    }
+
+    fun addToBuilder(builder: MultipartBodyBuilder)
+}
+
+└──────────────────────────────────────────────────────────────────────────────┘

--- a/packages/kotlin/tests/.verify/openapi-services/spring-reactive-web-clients-spring-boot-4.expect.txt
+++ b/packages/kotlin/tests/.verify/openapi-services/spring-reactive-web-clients-spring-boot-4.expect.txt
@@ -1,0 +1,436 @@
+┌──────────────────────────────────────┐
+│ state                                │
+├──────────────────────────────────────┤
+{
+  kotlin: {
+    clients: {
+      'service-1': {
+        __source__: 'tag:Pets',
+        packageName: 'com.openapi.generated.api.client',
+        typeName: 'PetsRequests'
+      }
+    },
+    models: {
+      'schema-1': {
+        __source__: '<root>/test/openapi-files/v3/service-endpoints.yml#/paths//pets/get/responses/200/content/application/json/schema',
+        type: KtReference {
+          classReference: false,
+          generics: [
+            KtReference {
+              classReference: false,
+              generics: [],
+              inject: {},
+              name: 'Pet',
+              nullable: false,
+              packageName: 'com.openapi.generated.model',
+              subReference: null
+            }
+          ],
+          inject: {},
+          name: 'List',
+          nullable: false,
+          packageName: 'kotlin.collections',
+          subReference: null
+        }
+      },
+      'schema-10': {
+        __source__: '<root>/test/openapi-files/v3/service-endpoints.yml#/components/schemas/Pet',
+        type: KtReference {
+          classReference: false,
+          generics: [],
+          inject: {},
+          name: 'Pet',
+          nullable: false,
+          packageName: 'com.openapi.generated.model',
+          subReference: null
+        }
+      },
+      'schema-11': {
+        __source__: '<root>/test/openapi-files/v3/service-endpoints.yml#/paths//pets/{id}/delete/parameters/0/schema',
+        type: KtReference {
+          classReference: false,
+          generics: [],
+          inject: {},
+          name: 'String',
+          nullable: false,
+          packageName: 'kotlin',
+          subReference: null
+        }
+      },
+      'schema-12': {
+        __source__: '<root>/test/openapi-files/v3/service-endpoints.yml#/components/schemas/Pet',
+        type: KtReference {
+          classReference: false,
+          generics: [],
+          inject: {},
+          name: 'Pet',
+          nullable: false,
+          packageName: 'com.openapi.generated.model',
+          subReference: null
+        }
+      },
+      'schema-13': {
+        __source__: '<root>/test/openapi-files/v3/service-endpoints.yml#/components/schemas/Owner',
+        type: KtReference {
+          classReference: false,
+          generics: [],
+          inject: {},
+          name: 'Owner',
+          nullable: false,
+          packageName: 'com.openapi.generated.model',
+          subReference: null
+        }
+      },
+      'schema-14': {
+        __source__: '<root>/test/openapi-files/v3/service-endpoints.yml#/components/schemas/Owner',
+        type: KtReference {
+          classReference: false,
+          generics: [],
+          inject: {},
+          name: 'Owner',
+          nullable: false,
+          packageName: 'com.openapi.generated.model',
+          subReference: null
+        }
+      },
+      'schema-15': {
+        __source__: '<root>/test/openapi-files/v3/service-endpoints.yml#/components/schemas/Owner/properties/name',
+        type: KtReference {
+          classReference: false,
+          generics: [],
+          inject: {},
+          name: 'String',
+          nullable: false,
+          packageName: 'kotlin',
+          subReference: null
+        }
+      },
+      'schema-2': {
+        __source__: '<root>/test/openapi-files/v3/service-endpoints.yml#/components/schemas/Pet',
+        type: KtReference {
+          classReference: false,
+          generics: [],
+          inject: {},
+          name: 'Pet',
+          nullable: false,
+          packageName: 'com.openapi.generated.model',
+          subReference: null
+        }
+      },
+      'schema-3': {
+        __source__: '<root>/test/openapi-files/v3/service-endpoints.yml#/components/schemas/Pet',
+        type: KtReference {
+          classReference: false,
+          generics: [],
+          inject: {},
+          name: 'Pet',
+          nullable: false,
+          packageName: 'com.openapi.generated.model',
+          subReference: null
+        }
+      },
+      'schema-4': {
+        __source__: '<root>/test/openapi-files/v3/service-endpoints.yml#/components/schemas/Pet/properties/id',
+        type: KtReference {
+          classReference: false,
+          generics: [],
+          inject: {},
+          name: 'String',
+          nullable: false,
+          packageName: 'kotlin',
+          subReference: null
+        }
+      },
+      'schema-5': {
+        __source__: '<root>/test/openapi-files/v3/service-endpoints.yml#/components/schemas/Pet/properties/name',
+        type: KtReference {
+          classReference: false,
+          generics: [],
+          inject: {},
+          name: 'String',
+          nullable: false,
+          packageName: 'kotlin',
+          subReference: null
+        }
+      },
+      'schema-6': {
+        __source__: '<root>/test/openapi-files/v3/service-endpoints.yml#/components/schemas/Pet/properties/tag',
+        type: KtReference {
+          classReference: false,
+          generics: [],
+          inject: {},
+          name: 'String',
+          nullable: false,
+          packageName: 'kotlin',
+          subReference: null
+        }
+      },
+      'schema-7': {
+        __source__: '<root>/test/openapi-files/v3/service-endpoints.yml#/components/schemas/Pet',
+        type: KtReference {
+          classReference: false,
+          generics: [],
+          inject: {},
+          name: 'Pet',
+          nullable: false,
+          packageName: 'com.openapi.generated.model',
+          subReference: null
+        }
+      },
+      'schema-8': {
+        __source__: '<root>/test/openapi-files/v3/service-endpoints.yml#/components/schemas/Pet',
+        type: KtReference {
+          classReference: false,
+          generics: [],
+          inject: {},
+          name: 'Pet',
+          nullable: false,
+          packageName: 'com.openapi.generated.model',
+          subReference: null
+        }
+      },
+      'schema-9': {
+        __source__: '<root>/test/openapi-files/v3/service-endpoints.yml#/paths//pets/{id}/get/parameters/0/schema',
+        type: KtReference {
+          classReference: false,
+          generics: [],
+          inject: {},
+          name: 'String',
+          nullable: false,
+          packageName: 'kotlin',
+          subReference: null
+        }
+      }
+    }
+  }
+}
+└──────────────────────────────────────┘
+
+┌────────────────────────────────────────┐
+│ out/com/openapi/generated/model/Pet.kt │
+├────────────────────────────────────────┤
+package com.openapi.generated.model
+
+import com.fasterxml.jackson.annotation.JsonProperty
+import io.swagger.v3.oas.annotations.media.Schema
+
+data class Pet(
+    @Schema(required = true)
+    @param:JsonProperty("id", required = true)
+    @get:JsonProperty("id", required = true)
+    val id: String,
+
+    @Schema(required = true)
+    @param:JsonProperty("name", required = true)
+    @get:JsonProperty("name", required = true)
+    val name: String,
+
+    @Schema
+    @param:JsonProperty("tag")
+    @get:JsonProperty("tag")
+    val tag: String? = null
+)
+
+└────────────────────────────────────────┘
+
+┌──────────────────────────────────────────┐
+│ out/com/openapi/generated/model/Owner.kt │
+├──────────────────────────────────────────┤
+package com.openapi.generated.model
+
+import com.fasterxml.jackson.annotation.JsonProperty
+import io.swagger.v3.oas.annotations.media.Schema
+
+data class Owner(
+    @Schema(required = true)
+    @param:JsonProperty("name", required = true)
+    @get:JsonProperty("name", required = true)
+    val name: String
+)
+
+└──────────────────────────────────────────┘
+
+┌──────────────────────────────────────────────────────┐
+│ out/com/openapi/generated/api/client/PetsRequests.kt │
+├──────────────────────────────────────────────────────┤
+package com.openapi.generated.api.client
+
+import com.openapi.generated.model.Pet
+import kotlinx.coroutines.reactive.awaitFirstOrNull
+import kotlinx.coroutines.reactor.mono
+import org.springframework.http.HttpMethod
+import org.springframework.http.MediaType
+import org.springframework.web.reactive.function.client.awaitBodilessEntity
+import org.springframework.web.reactive.function.client.awaitBody
+import org.springframework.web.reactive.function.client.ClientResponse
+import org.springframework.web.reactive.function.client.WebClient
+import org.springframework.web.reactive.function.client.WebClient.RequestHeadersSpec
+import org.springframework.web.util.UriComponentsBuilder
+
+object PetsRequests {
+    suspend fun WebClient.listPets(): List<Pet> {
+        return this
+            .listPetsRequest()
+            .retrieve()
+            .awaitBody<List<Pet>>()
+    }
+
+    suspend fun <T : Any> WebClient.listPets(responseHandler: suspend (ClientResponse) -> T): T {
+        return this.listPetsRequest()
+            .exchangeToMono { mono { responseHandler(it) } }
+            .awaitFirstOrNull() as T
+    }
+
+    fun listPetsUri(): String {
+        return UriComponentsBuilder.fromPath("pets")
+            .build()
+            .toUriString()
+    }
+
+    fun WebClient.listPetsRequest(): RequestHeadersSpec<*> {
+        return this.method(HttpMethod.GET)
+            .uri(listPetsUri())
+            .accept(MediaType.APPLICATION_JSON)
+    }
+
+    suspend fun WebClient.createPet(pet: Pet): Pet {
+        return this
+            .createPetRequest(pet)
+            .retrieve()
+            .awaitBody<Pet>()
+    }
+
+    suspend fun <T : Any> WebClient.createPet(pet: Pet, responseHandler: suspend (ClientResponse) -> T): T {
+        return this.createPetRequest(pet)
+            .exchangeToMono { mono { responseHandler(it) } }
+            .awaitFirstOrNull() as T
+    }
+
+    fun createPetUri(): String {
+        return UriComponentsBuilder.fromPath("pets")
+            .build()
+            .toUriString()
+    }
+
+    fun WebClient.createPetRequest(pet: Pet): RequestHeadersSpec<*> {
+        return this.method(HttpMethod.POST)
+            .uri(createPetUri())
+            .accept(MediaType.APPLICATION_JSON)
+            .contentType(MediaType.parseMediaType("application/json"))
+            .bodyValue(pet)
+    }
+
+    suspend fun WebClient.getPet(id: String): Pet {
+        return this
+            .getPetRequest(id)
+            .retrieve()
+            .awaitBody<Pet>()
+    }
+
+    suspend fun <T : Any> WebClient.getPet(id: String, responseHandler: suspend (ClientResponse) -> T): T {
+        return this.getPetRequest(id)
+            .exchangeToMono { mono { responseHandler(it) } }
+            .awaitFirstOrNull() as T
+    }
+
+    fun getPetUri(id: String): String {
+        return UriComponentsBuilder.fromPath("pets/{id}")
+            .buildAndExpand(mapOf("id" to id.toString()))
+            .toUriString()
+    }
+
+    fun WebClient.getPetRequest(id: String): RequestHeadersSpec<*> {
+        return this.method(HttpMethod.GET)
+            .uri(getPetUri(id))
+            .accept(MediaType.APPLICATION_JSON)
+    }
+
+    suspend fun WebClient.deletePet(id: String): Unit {
+        this
+            .deletePetRequest(id)
+            .retrieve()
+            .awaitBodilessEntity()
+    }
+
+    suspend fun <T : Any> WebClient.deletePet(id: String, responseHandler: suspend (ClientResponse) -> T): T {
+        return this.deletePetRequest(id)
+            .exchangeToMono { mono { responseHandler(it) } }
+            .awaitFirstOrNull() as T
+    }
+
+    fun deletePetUri(id: String): String {
+        return UriComponentsBuilder.fromPath("pets/{id}")
+            .buildAndExpand(mapOf("id" to id.toString()))
+            .toUriString()
+    }
+
+    fun WebClient.deletePetRequest(id: String): RequestHeadersSpec<*> {
+        return this.method(HttpMethod.DELETE).uri(deletePetUri(id))
+    }
+
+    suspend fun WebClient.searchPets(): Pet {
+        return this
+            .searchPetsRequest()
+            .retrieve()
+            .awaitBody<Pet>()
+    }
+
+    suspend fun <T : Any> WebClient.searchPets(responseHandler: suspend (ClientResponse) -> T): T {
+        return this.searchPetsRequest()
+            .exchangeToMono { mono { responseHandler(it) } }
+            .awaitFirstOrNull() as T
+    }
+
+    fun searchPetsUri(): String {
+        return UriComponentsBuilder.fromPath("pets/search")
+            .build()
+            .toUriString()
+    }
+
+    fun WebClient.searchPetsRequest(): RequestHeadersSpec<*> {
+        return this.method(HttpMethod.GET)
+            .uri(searchPetsUri())
+            .accept(MediaType.APPLICATION_JSON)
+    }
+}
+
+└──────────────────────────────────────────────────────┘
+
+┌──────────────────────────────────────────────────────────────────────────────┐
+│ <root>/out/com/openapi/generated/api/client/infrastructure/ApiRequestFile.kt │
+├──────────────────────────────────────────────────────────────────────────────┤
+package com.openapi.generated.api.client.infrastructure
+
+import org.springframework.core.io.buffer.DataBuffer
+import org.springframework.http.MediaType
+import org.springframework.http.client.MultipartBodyBuilder
+import org.springframework.http.codec.multipart.FilePart
+import java.io.File
+
+interface ApiRequestFile {
+    companion object {
+        fun from(file: File): ApiRequestFile =
+            object : ApiRequestFile {
+                override fun addToBuilder(builder: MultipartBodyBuilder) {
+                    builder
+                        .part("file", file)
+                        .filename(file.name)
+                        .contentType(MediaType.APPLICATION_OCTET_STREAM)
+                }
+            }
+
+        fun from(filePart: FilePart): ApiRequestFile =
+            object : ApiRequestFile {
+                override fun addToBuilder(builder: MultipartBodyBuilder) {
+                    builder
+                        .asyncPart("file", filePart.content(), DataBuffer::class.java)
+                        .filename(filePart.filename())
+                        .contentType(filePart.headers().contentType ?: MediaType.APPLICATION_OCTET_STREAM)
+                }
+            }
+    }
+
+    fun addToBuilder(builder: MultipartBodyBuilder)
+}
+
+└──────────────────────────────────────────────────────────────────────────────┘

--- a/packages/kotlin/tests/openapi-services.test.ts
+++ b/packages/kotlin/tests/openapi-services.test.ts
@@ -1,0 +1,76 @@
+import { join } from 'node:path';
+
+import { afterEach, describe, test } from '@std/testing/bdd';
+import { restore, stub } from '@std/testing/mock';
+
+// @deno-types="npm:@types/fs-extra@11"
+import fs from 'fs-extra';
+
+import { OpenApiGenerator } from '@goast/core';
+import { MultipartData, openApiV3FilesDir, verify } from '@goast/test-utils';
+
+import { KotlinModelsGenerator } from '../src/generators/models/models-generator.ts';
+import { KotlinOkHttp3ClientsGenerator } from '../src/generators/services/okhttp3-clients/okhttp3-clients-generator.ts';
+import { KotlinSpringControllersGenerator } from '../src/generators/services/spring-controllers/spring-controllers-generator.ts';
+import { KotlinSpringReactiveWebClientsGenerator } from '../src/generators/services/spring-reactive-web-clients/spring-reactive-web-clients-generator.ts';
+import type { SpringBootVersion } from '../src/config.ts';
+
+const specFile = join(openApiV3FilesDir, 'service-endpoints.yml');
+
+// deno-lint-ignore no-explicit-any
+const generators: { name: string; useType: (generator: OpenApiGenerator, config: any) => OpenApiGenerator }[] = [
+  {
+    name: 'spring controllers',
+    useType: (generator, config) =>
+      generator.useType(KotlinModelsGenerator, config).useType(KotlinSpringControllersGenerator, config),
+  },
+  {
+    name: 'spring controllers strict response entities',
+    useType: (generator, config) =>
+      generator
+        .useType(KotlinModelsGenerator, config)
+        .useType(KotlinSpringControllersGenerator, { ...config, strictResponseEntities: true }),
+  },
+  {
+    name: 'spring reactive web clients',
+    useType: (generator, config) =>
+      generator.useType(KotlinModelsGenerator, config).useType(KotlinSpringReactiveWebClientsGenerator, config),
+  },
+  {
+    name: 'okhttp3 clients',
+    useType: (generator, config) =>
+      generator.useType(KotlinModelsGenerator, config).useType(KotlinOkHttp3ClientsGenerator, config),
+  },
+];
+
+const springBootVersions: SpringBootVersion[] = [3, 4];
+
+for (const { name, useType } of generators) {
+  describe(name, () => {
+    afterEach(() => {
+      restore();
+    });
+
+    for (const springBootVersion of springBootVersions) {
+      test(`spring boot ${springBootVersion}`, async (t) => {
+        const result = new MultipartData();
+        stub(fs, 'ensureDirSync');
+        stub(fs, 'writeFileSync', (path: fs.PathOrFileDescriptor, data: string | NodeJS.ArrayBufferView) => {
+          result.push([path.toString(), data.toString()]);
+        });
+
+        const generatorOptions = {
+          outputDir: 'out',
+          newLine: '\n',
+        };
+        // deno-lint-ignore no-explicit-any
+        const config = { __test__: true, springBootVersion } as any;
+        const state = await useType(new OpenApiGenerator(generatorOptions), config).parseAndGenerate(specFile);
+        result.splice(0, 0, ['state', state]);
+
+        restore();
+        await verify(t, result);
+      });
+    }
+  });
+}

--- a/test/openapi-files/v3/service-endpoints.yml
+++ b/test/openapi-files/v3/service-endpoints.yml
@@ -1,0 +1,104 @@
+openapi: 3.0.0
+info:
+  version: 1.0.0
+  title: Service Endpoints
+
+paths:
+  /pets:
+    get:
+      operationId: listPets
+      tags: [Pets]
+      responses:
+        '200':
+          description: A list of pets.
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Pet'
+    post:
+      operationId: createPet
+      tags: [Pets]
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Pet'
+      responses:
+        '201':
+          description: The created pet.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Pet'
+        '400':
+          description: Invalid input.
+  /pets/{id}:
+    get:
+      operationId: getPet
+      tags: [Pets]
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: The requested pet.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Pet'
+        '404':
+          description: Pet not found.
+    delete:
+      operationId: deletePet
+      tags: [Pets]
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        '204':
+          description: Pet deleted.
+  /pets/search:
+    get:
+      operationId: searchPets
+      tags: [Pets]
+      responses:
+        '200':
+          description: A pet.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Pet'
+        '202':
+          description: An owner.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Owner'
+
+components:
+  schemas:
+    Pet:
+      type: object
+      required: [id, name]
+      properties:
+        id:
+          type: string
+        name:
+          type: string
+        tag:
+          type: string
+    Owner:
+      type: object
+      required: [name]
+      properties:
+        name:
+          type: string


### PR DESCRIPTION
## What

Adds native **Spring Boot 4** output support to the Kotlin generators, gated behind a new generator option, and releases it as **`@goast/kotlin` 0.5.10**:

```ts
springBootVersion?: 3 | 4; // default: 3
```

- **`3` (default):** output is identical to before — no change for existing consumers (one intentional exception below).
- **`4`:** generators emit Kotlin that compiles against **Spring Boot 4.1 / Spring Framework 7 / Jackson 3 / Kotlin 2.x with JSpecify null-safety**.

The option is added to the base `KotlinGeneratorConfig`, so it flows through the spring-controllers, spring-reactive-web-clients, okhttp3-clients, and models generators. Each affected generator branches on `ctx.config.springBootVersion === 4`.

## Why

Spring Boot 4 ships Spring Framework 7, Jackson 3, and JSpecify null-safety. Jackson-2/Spring-6 Kotlin emitted today no longer compiles under Boot 4. This lets goast emit Boot-4-correct Kotlin natively instead of consumers post-processing the generated output.

## Changes (gated on `springBootVersion === 4` unless noted)

**Group 1 — Jackson 2 → 3 package moves**
- `src/ast/references/jackson.ts`: the moving symbols (`objectMapper`, `serializationFeature`, `deserializationFeature`, `jacksonObjectMapper`, new `jacksonMapperBuilder`) resolve `com.fasterxml.jackson.*` → `tools.jackson.*` based on the version. **Annotations stay on `com.fasterxml.jackson.annotation`.**
- okhttp3 generator call sites pass `ctx.config.springBootVersion`.
- Copied okhttp3 assets have their `com.fasterxml.jackson.{core,databind,module,datatype,dataformat}` imports rewritten to `tools.jackson.*` at copy time.
- The static okhttp3 `Serializer.kt` is rebuilt via the immutable Jackson 3 mapper builder (`jacksonMapperBuilder().findAndAddModules().changeDefaultPropertyInclusion { … }.configure(…).build()`), since Jackson 3's `ObjectMapper` no longer exposes `findAndRegisterModules()` / `setSerializationInclusion()` / `configure()`.

**Group 2 — Spring 7 reactive `WebClient` generic bound**
- `<T>` → `<T : Any>` on the `WebClient.<op>` handler overloads so Spring 7's `exchangeToMono` (`<V : Any>`) infers.

**Group 3 — Spring 7 `ResponseEntity<T : Any>` (controllers)**
- Typed `ResponseEntity` subclass generic bounded as `<T : Any>`; subclass body parameter made nullable (`T?`) so null-body responses stay legal and **wire-identical**; no-body factories emit `<Unit>` (keeping the `null` body argument); delegate default methods use a non-null `Any` fallback.

**okhttp 5 compatibility (applied unconditionally)**
- The Spring Boot 4.1 BOM pulls in okhttp 5, which removed `okhttp3.internal.EMPTY_REQUEST`. The copied `ApiClient.kt` asset now uses the public `ByteArray(0).toRequestBody(null)` for empty bodies and drops the `okhttp3.internal.EMPTY_REQUEST` import. This is behavior-identical and compiles on okhttp 4 **and** 5, so it is **not** gated on `springBootVersion` — it removes the only non-public-API reference in the copied assets and benefits all consumers. (This is the one intentional deviation from byte-identical SB3 output: a single behavior-preserving line.)

## Tests

- **Unit tests** (`src/ast/references/jackson.test.ts`): version-aware Jackson references resolve the right packages; annotations stay on `com.fasterxml`.
- **Snapshot tests** (`tests/openapi-services.test.ts` + `test/openapi-files/v3/service-endpoints.yml`): spring-controllers (incl. `strictResponseEntities`), reactive web clients, and okhttp3 clients generated under both Spring Boot 3 and 4. The v3 snapshots confirm the default path is unchanged (aside from the okhttp empty-body line); the v4 snapshots capture every adaptation above.

Full suite green: `107 passed`. `deno lint` and `deno check` clean.

## Notes

- No changes to model shapes, routing, suspend/Flux behavior, Jakarta validation, or Swagger annotations.
- Validated end-to-end against a real Spring Boot 4.1 project (Spring 7 / Jackson 3 / Kotlin, okhttp 5) — generated controllers, reactive clients, okhttp3 client, and infrastructure assets compile.
- Rebased onto current `main` (incl. #76); the Deno 2.8.2 CI pin is already upstream so that commit was dropped during rebase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
