### PR TITLE
fix: use awaitExchange instead of exchangeToMono

### DIFF
--- a/packages/kotlin/deno.json
+++ b/packages/kotlin/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@goast/kotlin",
-  "version": "0.5.10",
+  "version": "0.5.11",
   "description": "Provides gOAst generators for generating Kotlin code from OpenAPI specifications.",
   "exports": "./mod.ts",
   "publish": {

--- a/packages/kotlin/src/ast/references/spring-reactive.ts
+++ b/packages/kotlin/src/ast/references/spring-reactive.ts
@@ -31,3 +31,7 @@ export const awaitBodilessEntity: KtReferenceFactory = ktReference.factory(
   'awaitBodilessEntity',
   'org.springframework.web.reactive.function.client',
 );
+export const awaitExchange: KtReferenceFactory = ktReference.factory(
+  'awaitExchange',
+  'org.springframework.web.reactive.function.client',
+);

--- a/packages/kotlin/src/generators/services/spring-reactive-web-clients/spring-reactive-web-client-generator.ts
+++ b/packages/kotlin/src/generators/services/spring-reactive-web-clients/spring-reactive-web-client-generator.ts
@@ -146,7 +146,7 @@ export class DefaultKotlinSpringReactiveWebClientGenerator extends KotlinFileGen
     return kt.function(functionName, {
       doc: kt.doc(this.getEndpointDocDescription(ctx, { endpoint })),
       suspend: true,
-      // Spring 7's `WebClient.exchangeToMono` is `<V : Any>`, so the `<T>` overloads need an `Any` bound to infer.
+      // Spring 7's `WebClient.awaitExchange` is `<V : Any>`, so the `<T>` overloads need an `Any` bound to infer.
       generics: [
         kt.genericParameter('T', ctx.config.springBootVersion === 4 ? { constraint: kt.refs.any() } : undefined),
       ],
@@ -182,16 +182,9 @@ export class DefaultKotlinSpringReactiveWebClientGenerator extends KotlinFileGen
     result.values.push(s`return ${
       kt.call([
         kt.call(['this', requestFunctionName], parameterNames),
-        kt.call(['exchangeToMono'], [
-          kt.lambda(
-            [],
-            kt.call(kt.refs.kotlinx.mono.infer(), [kt.lambda([], 'responseHandler(it)', { singleline: true })]),
-            { singleline: true },
-          ),
-        ]),
-        kt.call([kt.refs.kotlinx.awaitFirstOrNull.infer()], []),
+        kt.call([kt.refs.springReactive.awaitExchange()], ['responseHandler']),
       ])
-    } as T`);
+    }`);
 
     return result;
   }

--- a/packages/kotlin/tests/.verify/openapi-services/spring-reactive-web-clients-spring-boot-3.expect.txt
+++ b/packages/kotlin/tests/.verify/openapi-services/spring-reactive-web-clients-spring-boot-3.expect.txt
@@ -256,12 +256,11 @@ data class Owner(
 package com.openapi.generated.api.client
 
 import com.openapi.generated.model.Pet
-import kotlinx.coroutines.reactive.awaitFirstOrNull
-import kotlinx.coroutines.reactor.mono
 import org.springframework.http.HttpMethod
 import org.springframework.http.MediaType
 import org.springframework.web.reactive.function.client.awaitBodilessEntity
 import org.springframework.web.reactive.function.client.awaitBody
+import org.springframework.web.reactive.function.client.awaitExchange
 import org.springframework.web.reactive.function.client.ClientResponse
 import org.springframework.web.reactive.function.client.WebClient
 import org.springframework.web.reactive.function.client.WebClient.RequestHeadersSpec
@@ -276,9 +275,7 @@ object PetsRequests {
     }
 
     suspend fun <T> WebClient.listPets(responseHandler: suspend (ClientResponse) -> T): T {
-        return this.listPetsRequest()
-            .exchangeToMono { mono { responseHandler(it) } }
-            .awaitFirstOrNull() as T
+        return this.listPetsRequest().awaitExchange(responseHandler)
     }
 
     fun listPetsUri(): String {
@@ -301,9 +298,7 @@ object PetsRequests {
     }
 
     suspend fun <T> WebClient.createPet(pet: Pet, responseHandler: suspend (ClientResponse) -> T): T {
-        return this.createPetRequest(pet)
-            .exchangeToMono { mono { responseHandler(it) } }
-            .awaitFirstOrNull() as T
+        return this.createPetRequest(pet).awaitExchange(responseHandler)
     }
 
     fun createPetUri(): String {
@@ -328,9 +323,7 @@ object PetsRequests {
     }
 
     suspend fun <T> WebClient.getPet(id: String, responseHandler: suspend (ClientResponse) -> T): T {
-        return this.getPetRequest(id)
-            .exchangeToMono { mono { responseHandler(it) } }
-            .awaitFirstOrNull() as T
+        return this.getPetRequest(id).awaitExchange(responseHandler)
     }
 
     fun getPetUri(id: String): String {
@@ -353,9 +346,7 @@ object PetsRequests {
     }
 
     suspend fun <T> WebClient.deletePet(id: String, responseHandler: suspend (ClientResponse) -> T): T {
-        return this.deletePetRequest(id)
-            .exchangeToMono { mono { responseHandler(it) } }
-            .awaitFirstOrNull() as T
+        return this.deletePetRequest(id).awaitExchange(responseHandler)
     }
 
     fun deletePetUri(id: String): String {
@@ -376,9 +367,7 @@ object PetsRequests {
     }
 
     suspend fun <T> WebClient.searchPets(responseHandler: suspend (ClientResponse) -> T): T {
-        return this.searchPetsRequest()
-            .exchangeToMono { mono { responseHandler(it) } }
-            .awaitFirstOrNull() as T
+        return this.searchPetsRequest().awaitExchange(responseHandler)
     }
 
     fun searchPetsUri(): String {

--- a/packages/kotlin/tests/.verify/openapi-services/spring-reactive-web-clients-spring-boot-4.expect.txt
+++ b/packages/kotlin/tests/.verify/openapi-services/spring-reactive-web-clients-spring-boot-4.expect.txt
@@ -256,12 +256,11 @@ data class Owner(
 package com.openapi.generated.api.client
 
 import com.openapi.generated.model.Pet
-import kotlinx.coroutines.reactive.awaitFirstOrNull
-import kotlinx.coroutines.reactor.mono
 import org.springframework.http.HttpMethod
 import org.springframework.http.MediaType
 import org.springframework.web.reactive.function.client.awaitBodilessEntity
 import org.springframework.web.reactive.function.client.awaitBody
+import org.springframework.web.reactive.function.client.awaitExchange
 import org.springframework.web.reactive.function.client.ClientResponse
 import org.springframework.web.reactive.function.client.WebClient
 import org.springframework.web.reactive.function.client.WebClient.RequestHeadersSpec
@@ -276,9 +275,7 @@ object PetsRequests {
     }
 
     suspend fun <T : Any> WebClient.listPets(responseHandler: suspend (ClientResponse) -> T): T {
-        return this.listPetsRequest()
-            .exchangeToMono { mono { responseHandler(it) } }
-            .awaitFirstOrNull() as T
+        return this.listPetsRequest().awaitExchange(responseHandler)
     }
 
     fun listPetsUri(): String {
@@ -301,9 +298,7 @@ object PetsRequests {
     }
 
     suspend fun <T : Any> WebClient.createPet(pet: Pet, responseHandler: suspend (ClientResponse) -> T): T {
-        return this.createPetRequest(pet)
-            .exchangeToMono { mono { responseHandler(it) } }
-            .awaitFirstOrNull() as T
+        return this.createPetRequest(pet).awaitExchange(responseHandler)
     }
 
     fun createPetUri(): String {
@@ -328,9 +323,7 @@ object PetsRequests {
     }
 
     suspend fun <T : Any> WebClient.getPet(id: String, responseHandler: suspend (ClientResponse) -> T): T {
-        return this.getPetRequest(id)
-            .exchangeToMono { mono { responseHandler(it) } }
-            .awaitFirstOrNull() as T
+        return this.getPetRequest(id).awaitExchange(responseHandler)
     }
 
     fun getPetUri(id: String): String {
@@ -353,9 +346,7 @@ object PetsRequests {
     }
 
     suspend fun <T : Any> WebClient.deletePet(id: String, responseHandler: suspend (ClientResponse) -> T): T {
-        return this.deletePetRequest(id)
-            .exchangeToMono { mono { responseHandler(it) } }
-            .awaitFirstOrNull() as T
+        return this.deletePetRequest(id).awaitExchange(responseHandler)
     }
 
     fun deletePetUri(id: String): String {
@@ -376,9 +367,7 @@ object PetsRequests {
     }
 
     suspend fun <T : Any> WebClient.searchPets(responseHandler: suspend (ClientResponse) -> T): T {
-        return this.searchPetsRequest()
-            .exchangeToMono { mono { responseHandler(it) } }
-            .awaitFirstOrNull() as T
+        return this.searchPetsRequest().awaitExchange(responseHandler)
     }
 
     fun searchPetsUri(): String {


### PR DESCRIPTION
This prevents a potential memory leak when the response body is not used by the responseHandler.